### PR TITLE
Fix browser bundler breakage from Node-only streaming/proxy re-exports

### DIFF
--- a/scripts/test-browser-bundle.sh
+++ b/scripts/test-browser-bundle.sh
@@ -39,9 +39,6 @@ export default defineConfig({
     },
     minify: false,
   },
-  resolve: {
-    conditions: ['browser', 'import', 'module', 'default'],
-  },
 });
 EOF
 
@@ -70,6 +67,16 @@ fi
 
 if echo "$OUTPUT" | grep -q '"path".*externalized'; then
   echo "❌ ERROR: path module is being imported (Node.js module in browser build)"
+  FAILED=1
+fi
+
+if echo "$OUTPUT" | grep -q '"node:stream"'; then
+  echo "❌ ERROR: node:stream is being imported (Node.js module in browser build)"
+  FAILED=1
+fi
+
+if echo "$OUTPUT" | grep -q '"node:http"'; then
+  echo "❌ ERROR: node:http is being imported (Node.js module in browser build)"
   FAILED=1
 fi
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,31 +210,5 @@ export const anonymize = anonymizeCore;
 export const anonymizeRegexOnly = anonymizeRegexOnlyCore;
 export const anonymizeWithNER = anonymizeWithNERCore;
 
-// Re-export streaming module (Node.js/Bun only)
-export {
-  AnonymizerStream,
-  createAnonymizerStream,
-  SentenceBuffer,
-  type StreamConfig,
-  type SentenceBufferConfig,
-  type StreamChunkEvent,
-  type StreamFinishEvent,
-} from "./streaming/index.js";
-
-// Re-export proxy module (Node.js/Bun only)
-export {
-  createRehydraFetch,
-  createRehydraProxy,
-  createRehydraProxyServer,
-  wrapLLMClient,
-  SSEParser,
-  detectProvider,
-  OpenAIProvider,
-  AnthropicProvider,
-  type RehydraFetchConfig,
-  type RehydraProxyConfig,
-  type RehydraProxyServerConfig,
-  type RehydraProxyServer,
-  type LLMContentProvider,
-  type SSEEvent,
-} from "./proxy/index.js";
+// Note: Streaming and proxy modules are Node.js/Bun only.
+// Import from 'rehydra/streaming' or 'rehydra/proxy' subpaths.

--- a/test/integration/streaming.test.ts
+++ b/test/integration/streaming.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { Readable } from "node:stream";
 import {
-  createAnonymizerStream,
   createAnonymizer,
   InMemoryKeyProvider,
   InMemoryPIIStorageProvider,
   decryptPIIMap,
   rehydrate,
 } from "../../src/index.js";
+import { createAnonymizerStream } from "../../src/streaming/index.js";
 
 async function collectStream(stream: NodeJS.ReadableStream): Promise<string> {
   const chunks: string[] = [];


### PR DESCRIPTION
## Summary

- Remove streaming and proxy re-exports from the main entry point (`src/index.ts`) — these modules import `node:stream` and `node:http`, which break browser bundlers (Vite/Rollup) that don't resolve via the `"browser"` export condition
- Streaming and proxy APIs remain available via `rehydra/streaming` and `rehydra/proxy` subpaths (already node-only in the exports map)
- Harden the browser bundle test by removing the explicit `resolve.conditions` override that was masking this issue, and add checks for `node:stream` and `node:http`

Closes #25

## Test plan

- [x] All 1014 unit/integration tests pass
- [x] Browser bundle test passes **without** explicit Vite conditions override
- [x] `import { Anonymizer } from "rehydra"` works in a default Vite build