### PR TITLE
Use streaming API for file-based CLI anonymization

### DIFF
--- a/src/cli/commands/anonymize.ts
+++ b/src/cli/commands/anonymize.ts
@@ -1,16 +1,24 @@
+import { pipeline } from "node:stream/promises";
 import {
   createAnonymizer,
   type AnonymizerConfig,
   type NERConfig,
+  type AnonymizationPolicy,
   PIIType,
   mergePolicy,
   generateKey,
   uint8ArrayToBase64,
   ConfigKeyProvider,
 } from "../../index.js";
+import {
+  createAnonymizerStream,
+  type StreamConfig,
+  type StreamChunkEvent,
+  type StreamFinishEvent,
+} from "../../streaming/index.js";
 import type { ParsedOptions } from "../main.js";
 import { CLIError } from "../utils/errors.js";
-import { readInput, writeOutput } from "../utils/io.js";
+import { readInput, writeOutput, getInputStream, getOutputStream } from "../utils/io.js";
 import { formatText, formatJson, formatNdjson, formatStats } from "../utils/format.js";
 import { savePIIMapFile, type PIIMapFile } from "../utils/pii-map-file.js";
 
@@ -64,6 +72,39 @@ function validateFormat(format: string): "text" | "json" | "ndjson" {
   return format;
 }
 
+function setupKeyProvider(options: ParsedOptions): {
+  keyProvider: ConfigKeyProvider;
+  keyBase64: string | undefined;
+} {
+  const envKey = process.env["REHYDRA_KEY"];
+  const flagKey = options.key;
+  const externalKey = flagKey ?? envKey;
+
+  if (externalKey !== undefined) {
+    return { keyProvider: new ConfigKeyProvider(externalKey), keyBase64: undefined };
+  }
+
+  const keyBytes = generateKey();
+  const keyBase64 = uint8ArrayToBase64(keyBytes);
+  return { keyProvider: new ConfigKeyProvider(keyBase64), keyBase64 };
+}
+
+function buildNerConfig(
+  nerMode: NERConfig["mode"],
+  quiet: boolean,
+): NERConfig | undefined {
+  if (nerMode === "disabled") return undefined;
+  return {
+    mode: nerMode,
+    autoDownload: true,
+    onStatus: quiet
+      ? undefined
+      : (status: string): void => {
+          process.stderr.write(`${status}\n`);
+        },
+  };
+}
+
 export async function anonymizeCommand(
   filePath: string | undefined,
   options: ParsedOptions,
@@ -71,48 +112,41 @@ export async function anonymizeCommand(
   const nerMode = validateNerMode(options.ner);
   const anonMode = validateMode(options.mode);
   const format = validateFormat(options.format);
+  const { keyProvider, keyBase64 } = setupKeyProvider(options);
+  const policy = options.types !== undefined
+    ? mergePolicy({ enabledTypes: parseTypes(options.types) })
+    : undefined;
 
-  const input = await readInput(filePath);
-
-  // Set up encryption key
-  const envKey = process.env["REHYDRA_KEY"];
-  const flagKey = options.key;
-  const externalKey = flagKey ?? envKey;
-
-  let keyBase64: string | undefined;
-  let keyProvider: ConfigKeyProvider;
-
-  if (externalKey !== undefined) {
-    keyProvider = new ConfigKeyProvider(externalKey);
-    // Don't store the key in the PII map file when user provides it
-  } else {
-    const keyBytes = generateKey();
-    keyBase64 = uint8ArrayToBase64(keyBytes);
-    keyProvider = new ConfigKeyProvider(keyBase64);
+  // Use streaming for file inputs, batch for stdin
+  if (filePath !== undefined) {
+    return anonymizeFile(filePath, options, nerMode, anonMode, format, keyProvider, keyBase64, policy);
   }
+  return anonymizeBatch(options, nerMode, anonMode, format, keyProvider, keyBase64, policy);
+}
 
-  // Build anonymizer config
+/**
+ * Batch anonymization for stdin input.
+ */
+async function anonymizeBatch(
+  options: ParsedOptions,
+  nerMode: NERConfig["mode"],
+  anonMode: "anonymize" | "pseudonymize",
+  format: "text" | "json" | "ndjson",
+  keyProvider: ConfigKeyProvider,
+  keyBase64: string | undefined,
+  policy: Partial<AnonymizationPolicy> | undefined,
+): Promise<number> {
+  const input = await readInput();
+
   const config: AnonymizerConfig = {
     mode: anonMode,
     keyProvider,
   };
 
-  if (nerMode !== "disabled") {
-    config.ner = {
-      mode: nerMode,
-      autoDownload: true,
-      onStatus: options.quiet
-        ? undefined
-        : (status: string): void => {
-            process.stderr.write(`${status}\n`);
-          },
-    };
+  const nerConfig = buildNerConfig(nerMode, options.quiet);
+  if (nerConfig !== undefined) {
+    config.ner = nerConfig;
   }
-
-  // Build policy with type filtering
-  const policy = options.types !== undefined
-    ? mergePolicy({ enabledTypes: parseTypes(options.types) })
-    : undefined;
 
   const anonymizer = createAnonymizer(config);
   await anonymizer.initialize();
@@ -167,9 +201,154 @@ export async function anonymizeCommand(
       process.stderr.write(formatStats(result.stats) + "\n");
     }
 
-    // Exit code 2 if no PII found
     return result.stats.totalEntities > 0 ? 0 : 2;
   } finally {
     await anonymizer.dispose();
   }
+}
+
+/**
+ * Streaming anonymization for file inputs.
+ */
+async function anonymizeFile(
+  filePath: string,
+  options: ParsedOptions,
+  nerMode: NERConfig["mode"],
+  anonMode: "anonymize" | "pseudonymize",
+  format: "text" | "json" | "ndjson",
+  keyProvider: ConfigKeyProvider,
+  keyBase64: string | undefined,
+  policy: Partial<AnonymizationPolicy> | undefined,
+): Promise<number> {
+  const countsByType: Record<string, number> = {};
+  const allEntities: { type: string; id: number; confidence: number; source: string; semantic?: unknown }[] = [];
+  const textChunks: string[] = [];
+  let finishData: StreamFinishEvent | undefined;
+
+  const anonymizerConfig: AnonymizerConfig = {
+    mode: anonMode,
+    keyProvider,
+  };
+
+  const nerConfig = buildNerConfig(nerMode, options.quiet);
+  if (nerConfig !== undefined) {
+    anonymizerConfig.ner = nerConfig;
+  }
+
+  const streamConfig: StreamConfig = {
+    anonymizer: anonymizerConfig,
+    policy: policy ?? undefined,
+    locale: options.locale,
+    keyProvider,
+    onChunk: (event: StreamChunkEvent) => {
+      for (const entity of event.entities) {
+        countsByType[entity.type] = (countsByType[entity.type] ?? 0) + 1;
+        allEntities.push({
+          type: entity.type,
+          id: entity.id,
+          confidence: entity.confidence,
+          source: entity.source,
+          ...(entity.semantic !== undefined ? { semantic: entity.semantic } : {}),
+        });
+      }
+    },
+    onFinish: (event: StreamFinishEvent) => {
+      finishData = event;
+    },
+  };
+
+  const anonymizerStream = await createAnonymizerStream(streamConfig);
+  const inputStream = getInputStream(filePath);
+  const outputStream = getOutputStream(options.output);
+
+  if (format === "text") {
+    // Direct pipe: input → anonymizer → output
+    await pipeline(inputStream, anonymizerStream, outputStream);
+    // Add trailing newline if writing to file
+    if (options.output !== undefined) {
+      outputStream.write("\n");
+    }
+  } else {
+    // For json/ndjson: collect output text, format at end
+    anonymizerStream.on("data", (chunk: Buffer | string) => {
+      textChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    });
+    inputStream.pipe(anonymizerStream);
+    await new Promise<void>((resolve, reject) => {
+      anonymizerStream.on("end", resolve);
+      anonymizerStream.on("error", reject);
+      inputStream.on("error", reject);
+    });
+
+    let output: string;
+    if (format === "json") {
+      output = JSON.stringify({
+        anonymizedText: textChunks.join(""),
+        entities: allEntities,
+        stats: {
+          totalEntities: finishData?.totalEntities ?? 0,
+          countsByType,
+          processingTimeMs: finishData?.totalProcessingTimeMs ?? 0,
+        },
+      }, null, 2);
+    } else {
+      // ndjson: entity lines + summary
+      const lines = allEntities.map((e) => JSON.stringify(e));
+      lines.push(
+        JSON.stringify({
+          _type: "summary",
+          anonymizedText: textChunks.join(""),
+          totalEntities: finishData?.totalEntities ?? 0,
+          processingTimeMs: finishData?.totalProcessingTimeMs ?? 0,
+        }),
+      );
+      output = lines.join("\n");
+    }
+
+    if (!output.endsWith("\n")) {
+      output += "\n";
+    }
+    await writeOutput(output, options.output);
+  }
+
+  // Close file output stream if writing to file (pipeline already handles this for text format)
+  if (format !== "text" && options.output !== undefined && outputStream !== process.stdout) {
+    await new Promise<void>((resolve) => outputStream.end(resolve));
+  }
+
+  // Save PII map
+  if (anonMode === "pseudonymize" && finishData?.piiMap !== undefined) {
+    const piiMapFile: PIIMapFile = {
+      version: 1,
+      createdAt: new Date().toISOString(),
+      ...(keyBase64 !== undefined ? { key: keyBase64 } : {}),
+      piiMap: finishData.piiMap,
+      stats: {
+        totalEntities: finishData.totalEntities,
+        countsByType,
+      },
+    };
+    await savePIIMapFile(options["pii-map"], piiMapFile);
+
+    if (!options.quiet) {
+      process.stderr.write(
+        `PII map saved to ${options["pii-map"]}\n`,
+      );
+    }
+  }
+
+  // Print stats to stderr if verbose
+  if (options.verbose && finishData !== undefined) {
+    process.stderr.write(
+      formatStats({
+        totalEntities: finishData.totalEntities,
+        countsByType: countsByType as Record<PIIType, number>,
+        processingTimeMs: finishData.totalProcessingTimeMs,
+        modelVersion: "",
+        policyVersion: "",
+      }) + "\n",
+    );
+  }
+
+  return (finishData?.totalEntities ?? 0) > 0 ? 0 : 2;
 }

--- a/src/cli/utils/io.ts
+++ b/src/cli/utils/io.ts
@@ -1,4 +1,6 @@
+import { createReadStream, createWriteStream } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
+import type { Readable, Writable } from "node:stream";
 import { text } from "node:stream/consumers";
 import { CLIError } from "./errors.js";
 
@@ -40,4 +42,21 @@ export async function writeOutput(
   } else {
     process.stdout.write(data);
   }
+}
+
+/**
+ * Get a readable stream for a file path.
+ */
+export function getInputStream(filePath: string): Readable {
+  return createReadStream(filePath, { encoding: "utf-8" });
+}
+
+/**
+ * Get a writable stream for output (file or stdout).
+ */
+export function getOutputStream(filePath?: string): Writable {
+  if (filePath !== undefined) {
+    return createWriteStream(filePath, { encoding: "utf-8" });
+  }
+  return process.stdout;
 }


### PR DESCRIPTION
## Summary
- When a file path is provided, `rehydra anonymize` now uses `createAnonymizerStream` instead of reading the entire file into memory
- Stdin input keeps the existing batch approach
- No new flags — streaming is used transparently under the hood for files
- All output formats (text, json, ndjson) work with the streaming path

Closes #22

## Test plan
- [x] All 1097 tests pass (existing file-based tests now exercise the streaming path)
- [x] Build clean