### PR TITLE
Add secrets/credentials detection for coding agent protection

### DIFF
--- a/src/cli/commands/anonymize.ts
+++ b/src/cli/commands/anonymize.ts
@@ -3,6 +3,7 @@ import {
   createAnonymizer,
   type AnonymizerConfig,
   type NERConfig,
+  type SecretsConfig,
   type AnonymizationPolicy,
   PIIType,
   mergePolicy,
@@ -105,6 +106,14 @@ function buildNerConfig(
   };
 }
 
+function buildSecretsConfig(options: ParsedOptions): SecretsConfig | undefined {
+  if (!options.secrets) return undefined;
+  return {
+    enabled: true,
+    envFiles: options["env-file"] !== undefined ? [options["env-file"]] : undefined,
+  };
+}
+
 export async function anonymizeCommand(
   filePath: string | undefined,
   options: ParsedOptions,
@@ -146,6 +155,11 @@ async function anonymizeBatch(
   const nerConfig = buildNerConfig(nerMode, options.quiet);
   if (nerConfig !== undefined) {
     config.ner = nerConfig;
+  }
+
+  const secretsConfig = buildSecretsConfig(options);
+  if (secretsConfig !== undefined) {
+    config.secrets = secretsConfig;
   }
 
   const anonymizer = createAnonymizer(config);
@@ -233,6 +247,11 @@ async function anonymizeFile(
   const nerConfig = buildNerConfig(nerMode, options.quiet);
   if (nerConfig !== undefined) {
     anonymizerConfig.ner = nerConfig;
+  }
+
+  const secretsConfig = buildSecretsConfig(options);
+  if (secretsConfig !== undefined) {
+    anonymizerConfig.secrets = secretsConfig;
   }
 
   const streamConfig: StreamConfig = {

--- a/src/cli/commands/inspect.ts
+++ b/src/cli/commands/inspect.ts
@@ -2,6 +2,7 @@ import {
   createAnonymizer,
   type AnonymizerConfig,
   type NERConfig,
+  type SecretsConfig,
   PIIType,
   mergePolicy,
   InMemoryKeyProvider,
@@ -58,6 +59,14 @@ export async function inspectCommand(
             process.stderr.write(`${status}\n`);
           },
     };
+  }
+
+  if (options.secrets) {
+    const secretsConfig: SecretsConfig = {
+      enabled: true,
+      envFiles: options["env-file"] !== undefined ? [options["env-file"]] : undefined,
+    };
+    config.secrets = secretsConfig;
   }
 
   const policy = options.types !== undefined

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -18,6 +18,8 @@ export interface ParsedOptions {
   types?: string;
   mode: string;
   locale?: string;
+  secrets: boolean;
+  "env-file"?: string;
   verbose: boolean;
   quiet: boolean;
 }
@@ -43,6 +45,8 @@ ${bold("OPTIONS")}
       --types <types>      Comma-separated PII types to detect (default: all)
       --mode <mode>        anonymize | pseudonymize (default: pseudonymize)
       --locale <locale>    Locale hint for detection (e.g., de-DE)
+      --secrets            Enable secrets/credentials detection
+      --env-file <file>    .env file path for literal value redaction
       --no-color           Disable colored output
       --verbose            Show detection details
   -q, --quiet              Suppress non-essential output
@@ -87,6 +91,8 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<numbe
         types: { type: "string" },
         mode: { type: "string", default: "pseudonymize" },
         locale: { type: "string" },
+        secrets: { type: "boolean", default: false },
+        "env-file": { type: "string" },
         "no-color": { type: "boolean", default: false },
         verbose: { type: "boolean", default: false },
         quiet: { type: "boolean", short: "q", default: false },
@@ -136,6 +142,8 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<numbe
     types: values["types"] as string | undefined,
     mode: (values["mode"] as string | undefined) ?? "pseudonymize",
     locale: values["locale"] as string | undefined,
+    secrets: values["secrets"] === true || values["env-file"] !== undefined,
+    "env-file": values["env-file"] as string | undefined,
     verbose: values["verbose"] === true,
     quiet: values["quiet"] === true,
   };

--- a/src/core/anonymizer.ts
+++ b/src/core/anonymizer.ts
@@ -10,15 +10,19 @@ import {
   AnonymizationMode,
   DetectedEntity,
   SemanticConfig,
+  SecretsConfig,
   SpanMatch,
   PIIType,
   createDefaultPolicy,
+  SECRET_PII_TYPES,
 } from "../types/index.js";
 
 import {
   createDefaultRegistry,
   RecognizerRegistry,
+  createSecretRecognizers,
 } from "../recognizers/index.js";
+import { createLiteralValueRecognizer } from "../recognizers/secrets/literal-value.js";
 
 import {
   type INERModel,
@@ -224,6 +228,13 @@ export interface AnonymizerConfig {
    */
   semantic?: SemanticConfig;
 
+  /**
+   * Secrets/credentials detection configuration
+   * Detects API keys, private keys, JWTs, connection strings, etc.
+   * @default { enabled: false }
+   */
+  secrets?: SecretsConfig;
+
   /** Key provider for encryption (generates random key if not provided) */
   keyProvider?: KeyProvider;
 
@@ -262,6 +273,7 @@ export class Anonymizer {
   private nerModel: INERModel | null = null;
   private nerConfig: NERConfig;
   private semanticConfig: SemanticConfig;
+  private secretsConfig: SecretsConfig;
   private mode: AnonymizationMode;
   private keyProvider: KeyProvider | null;
   private piiStorageProvider: PIIStorageProvider | null;
@@ -310,6 +322,29 @@ export class Anonymizer {
         ...this.defaultPolicy,
         enableSemanticMasking: true,
       };
+    }
+
+    // Handle secrets configuration
+    this.secretsConfig = config.secrets ?? { enabled: false };
+
+    if (this.secretsConfig.enabled) {
+      // Add secret types to enabled types and regex enabled types
+      const enabledTypes = new Set(this.defaultPolicy.enabledTypes);
+      const regexEnabledTypes = new Set(this.defaultPolicy.regexEnabledTypes);
+      for (const secretType of SECRET_PII_TYPES) {
+        enabledTypes.add(secretType);
+        regexEnabledTypes.add(secretType);
+      }
+      this.defaultPolicy = {
+        ...this.defaultPolicy,
+        enabledTypes,
+        regexEnabledTypes,
+      };
+
+      // Register secret recognizers
+      for (const recognizer of createSecretRecognizers()) {
+        this.registry.register(recognizer);
+      }
     }
   }
 
@@ -436,6 +471,35 @@ export class Anonymizer {
       // Load data into memory for synchronous access during enrichment
       await loadSemanticData();
       this.semanticDataReady = true;
+    }
+
+    // Handle secrets .env file loading and literal value matching
+    if (this.secretsConfig.enabled) {
+      const literalValues: string[] = [
+        ...(this.secretsConfig.redactValues ?? []),
+      ];
+      const minLength = this.secretsConfig.minValueLength ?? 8;
+
+      // Parse .env files if provided
+      if (this.secretsConfig.envFiles !== undefined && this.secretsConfig.envFiles.length > 0) {
+        const storage = await getStorageProvider();
+        for (const envFile of this.secretsConfig.envFiles) {
+          try {
+            const content = await storage.readTextFile(envFile);
+            const parsed = parseEnvFile(content);
+            literalValues.push(...parsed);
+          } catch {
+            // Skip files that can't be read
+          }
+        }
+      }
+
+      // Register literal value recognizer if we have values
+      if (literalValues.length > 0) {
+        this.registry.register(
+          createLiteralValueRecognizer(literalValues, minLength),
+        );
+      }
     }
 
     this.modelVersion = this.nerModel.version;
@@ -781,4 +845,28 @@ export async function anonymizeWithNER(
   } finally {
     await anonymizer.dispose();
   }
+}
+
+/**
+ * Parses a .env file content and returns values
+ */
+function parseEnvFile(content: string): string[] {
+  const values: string[] = [];
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Skip comments and empty lines
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+
+    // Match KEY=VALUE (with optional export prefix and quotes)
+    const match = trimmed.match(
+      /^(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=\s*["']?(.*?)["']?$/,
+    );
+    if (match !== null && match[1] !== undefined && match[1] !== "") {
+      values.push(match[1]);
+    }
+  }
+
+  return values;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,8 @@ import { AnonymizerSessionImpl } from "./storage/session.js";
 
 // Re-export types from core
 export type { AnonymizerConfig, NERConfig };
+export type { SecretsConfig } from "./types/index.js";
+export { createSecretRecognizers } from "./recognizers/secrets/index.js";
 
 /**
  * Anonymizer instance

--- a/src/recognizers/index.ts
+++ b/src/recognizers/index.ts
@@ -20,6 +20,9 @@ export {
   isStructuredId,
 } from './custom-id.js';
 
+export { createSecretRecognizers } from './secrets/index.js';
+export * from './secrets/index.js';
+
 import { RecognizerRegistry } from './registry.js';
 import { emailRecognizer } from './email.js';
 import { phoneRecognizer } from './phone.js';

--- a/src/recognizers/secrets/api-key.ts
+++ b/src/recognizers/secrets/api-key.ts
@@ -1,0 +1,40 @@
+/**
+ * API Key Recognizer
+ * Detects provider-specific API key patterns
+ */
+
+import { createRegexRecognizer } from "../base.js";
+import { PIIType } from "../../types/index.js";
+
+export const apiKeyRecognizer = createRegexRecognizer({
+  type: PIIType.API_KEY,
+  name: "API Key",
+  defaultConfidence: 0.97,
+  patterns: [
+    // OpenAI
+    /\bsk-proj-[A-Za-z0-9_-]{20,}\b/g,
+    /\bsk-[A-Za-z0-9]{20,}\b/g,
+    // Anthropic
+    /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
+    // GitHub (PAT, OAuth, App, Installation, Refresh)
+    /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g,
+    // Stripe
+    /\b[sr]k_(?:live|test)_[A-Za-z0-9]{24,}\b/g,
+    // Slack bot/user tokens
+    /\bxox[bpas]-[0-9]{10,}-[A-Za-z0-9-]+/g,
+    // SendGrid
+    /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}\b/g,
+    // Twilio
+    /\bSK[a-f0-9]{32}\b/g,
+    // Mailgun
+    /\bkey-[a-f0-9]{32}\b/g,
+    // Heroku
+    /\b[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\b/g,
+  ],
+  validate(match: string): boolean {
+    // Heroku-style UUIDs are too generic without context — skip them
+    if (/^[a-f0-9]{8}-[a-f0-9]{4}-/.test(match)) return false;
+    // Must be at least 20 chars for non-prefixed patterns
+    return match.length >= 20;
+  },
+});

--- a/src/recognizers/secrets/aws-credentials.ts
+++ b/src/recognizers/secrets/aws-credentials.ts
@@ -1,0 +1,74 @@
+/**
+ * AWS Credentials Recognizer
+ * Detects AWS access key IDs (AKIA prefix) and context-dependent secret keys
+ */
+
+import { PIIType, type SpanMatch, DetectionSource } from "../../types/index.js";
+import type { Recognizer } from "../base.js";
+
+const AWS_ACCESS_KEY_PATTERN = /\bAKIA[A-Z0-9]{16}\b/g;
+
+const AWS_SECRET_CONTEXT_KEYWORDS = /(?:aws_secret_access_key|secret_access_key|aws_secret|secretaccesskey)/i;
+
+const AWS_SECRET_KEY_PATTERN = /\b[A-Za-z0-9/+=]{40}\b/g;
+
+export const awsCredentialsRecognizer: Recognizer = {
+  type: PIIType.AWS_CREDENTIALS,
+  name: "AWS Credentials",
+  defaultConfidence: 0.98,
+
+  find(text: string): SpanMatch[] {
+    const matches: SpanMatch[] = [];
+    const seen = new Set<string>();
+
+    // Always detect AKIA access key IDs (high confidence, distinctive prefix)
+    for (const match of text.matchAll(AWS_ACCESS_KEY_PATTERN)) {
+      if (match.index === undefined) continue;
+      const key = `${match.index}:${match.index + match[0].length}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      matches.push({
+        type: PIIType.AWS_CREDENTIALS,
+        start: match.index,
+        end: match.index + match[0].length,
+        confidence: 0.98,
+        source: DetectionSource.REGEX,
+        text: match[0],
+      });
+    }
+
+    // Only scan for 40-char secret keys if there's context suggesting AWS secrets
+    if (AWS_SECRET_CONTEXT_KEYWORDS.test(text)) {
+      for (const match of text.matchAll(AWS_SECRET_KEY_PATTERN)) {
+        if (match.index === undefined) continue;
+        const matchText = match[0];
+        const key = `${match.index}:${match.index + matchText.length}`;
+        if (seen.has(key)) continue;
+
+        // Must contain mixed case + digits/special to look like a secret
+        if (!/[a-z]/.test(matchText) || !/[A-Z]/.test(matchText)) continue;
+        if (!/[0-9/+=]/.test(matchText)) continue;
+
+        seen.add(key);
+        matches.push({
+          type: PIIType.AWS_CREDENTIALS,
+          start: match.index,
+          end: match.index + matchText.length,
+          confidence: 0.85,
+          source: DetectionSource.REGEX,
+          text: matchText,
+        });
+      }
+    }
+
+    return matches;
+  },
+
+  validate(match: string): boolean {
+    // AKIA keys are always valid
+    if (match.startsWith("AKIA") && match.length === 20) return true;
+    // Secret keys must be exactly 40 chars
+    return match.length === 40;
+  },
+};

--- a/src/recognizers/secrets/config-secret.ts
+++ b/src/recognizers/secrets/config-secret.ts
@@ -1,0 +1,72 @@
+/**
+ * Config Secret Recognizer
+ * Detects key-value secrets in JSON, YAML, and TOML
+ */
+
+import { PIIType, type SpanMatch, DetectionSource } from "../../types/index.js";
+import type { Recognizer } from "../base.js";
+import { isSecretKeyName } from "./key-patterns.js";
+
+// JSON: "key": "value" or 'key': 'value'
+const JSON_SECRET = /["']([a-zA-Z_][a-zA-Z0-9_.-]*)["']\s*:\s*["']([^"'\n]{8,})["']/g;
+
+// YAML: key: value (unquoted or quoted)
+const YAML_SECRET = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_.-]*)\s*:\s*["']?([^\n"'#]{8,})["']?$/gm;
+
+// TOML: key = "value"
+const TOML_SECRET = /^[ \t]*([a-zA-Z_][a-zA-Z0-9_.-]*)\s*=\s*["']([^"'\n]{8,})["']$/gm;
+
+const DEFAULT_MIN_LENGTH = 8;
+
+export function createConfigSecretRecognizer(
+  minValueLength: number = DEFAULT_MIN_LENGTH,
+  extraKeyPatterns: RegExp[] = [],
+): Recognizer {
+  return {
+    type: PIIType.CONFIG_SECRET,
+    name: "Config Secret",
+    defaultConfidence: 0.85,
+
+    find(text: string): SpanMatch[] {
+      const matches: SpanMatch[] = [];
+      const seen = new Set<string>();
+
+      const patterns = [JSON_SECRET, YAML_SECRET, TOML_SECRET];
+
+      for (const pattern of patterns) {
+        const p = new RegExp(pattern.source, pattern.flags);
+        for (const match of text.matchAll(p)) {
+          if (match.index === undefined) continue;
+          const key = match[1]!;
+          const value = match[2]!.trim();
+
+          const keyIsSecret = isSecretKeyName(key)
+            || extraKeyPatterns.some((pat) => pat.test(key));
+          if (!keyIsSecret) continue;
+          if (value.length < minValueLength) continue;
+
+          // Find exact position of value in the matched text
+          const fullMatch = match[0];
+          const valueStartInMatch = fullMatch.lastIndexOf(value);
+          const valueStart = match.index + valueStartInMatch;
+          const spanKey = `${valueStart}:${valueStart + value.length}`;
+          if (seen.has(spanKey)) continue;
+          seen.add(spanKey);
+
+          matches.push({
+            type: PIIType.CONFIG_SECRET,
+            start: valueStart,
+            end: valueStart + value.length,
+            confidence: 0.85,
+            source: DetectionSource.REGEX,
+            text: value,
+          });
+        }
+      }
+
+      return matches;
+    },
+  };
+}
+
+export const configSecretRecognizer = createConfigSecretRecognizer();

--- a/src/recognizers/secrets/connection-string.ts
+++ b/src/recognizers/secrets/connection-string.ts
@@ -1,0 +1,41 @@
+/**
+ * Connection String Recognizer
+ * Detects database/service URIs with embedded credentials
+ */
+
+import { createRegexRecognizer } from "../base.js";
+import { PIIType } from "../../types/index.js";
+
+const PLACEHOLDER_PASSWORDS = new Set([
+  "password", "pass", "changeme", "secret", "xxx", "yyy",
+  "your-password", "your_password", "example", "<password>",
+]);
+
+export const connectionStringRecognizer = createRegexRecognizer({
+  type: PIIType.CONNECTION_STRING,
+  name: "Connection String",
+  defaultConfidence: 0.93,
+  patterns: [
+    // postgres://user:password@host/db
+    /\b(?:postgres(?:ql)?|mysql|mariadb):\/\/[^\s:]+:[^\s@]+@[^\s]+/g,
+    // mongodb+srv://user:password@host/db
+    /\bmongodb(?:\+srv)?:\/\/[^\s:]+:[^\s@]+@[^\s]+/g,
+    // redis://user:password@host:port or redis://:password@host:port
+    /\brediss?:\/\/(?:[^\s:]*:)?[^\s@]+@[^\s]+/g,
+    // amqp://user:password@host:port
+    /\bamqps?:\/\/[^\s:]+:[^\s@]+@[^\s]+/g,
+  ],
+  validate(match: string): boolean {
+    // Extract password portion (between first : after // and @)
+    const credMatch = match.match(/:\/\/[^:]*:([^@]+)@/);
+    if (credMatch === null) return false;
+
+    const password = credMatch[1]!;
+    // Reject placeholder passwords
+    if (PLACEHOLDER_PASSWORDS.has(password.toLowerCase())) return false;
+    // Reject very short passwords (likely placeholders)
+    if (password.length < 4) return false;
+
+    return true;
+  },
+});

--- a/src/recognizers/secrets/env-var.ts
+++ b/src/recognizers/secrets/env-var.ts
@@ -1,0 +1,66 @@
+/**
+ * Environment Variable Secret Recognizer
+ * Detects secrets in .env-style KEY=VALUE lines
+ */
+
+import { PIIType, type SpanMatch, DetectionSource } from "../../types/index.js";
+import type { Recognizer } from "../base.js";
+import { isSecretKeyName } from "./key-patterns.js";
+
+const ENV_VAR_LINE = /^[ \t]*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=[ \t]*["']?(.+?)["']?$/gm;
+
+const PLACEHOLDER_VALUES = new Set([
+  "changeme", "your-api-key-here", "your_api_key_here",
+  "xxx", "yyy", "zzz", "todo", "fixme", "replace_me",
+  "example", "test", "dummy", "placeholder",
+]);
+
+const DEFAULT_MIN_LENGTH = 8;
+
+export function createEnvVarSecretRecognizer(
+  minValueLength: number = DEFAULT_MIN_LENGTH,
+  extraKeyPatterns: RegExp[] = [],
+): Recognizer {
+  return {
+    type: PIIType.ENV_VAR_SECRET,
+    name: "Environment Variable Secret",
+    defaultConfidence: 0.88,
+
+    find(text: string): SpanMatch[] {
+      const matches: SpanMatch[] = [];
+
+      for (const match of text.matchAll(ENV_VAR_LINE)) {
+        if (match.index === undefined) continue;
+        const key = match[1]!;
+        const value = match[2]!;
+
+        // Check if key name suggests a secret
+        const keyIsSecret = isSecretKeyName(key)
+          || extraKeyPatterns.some((p) => p.test(key));
+        if (!keyIsSecret) continue;
+
+        // Filter out short or placeholder values
+        if (value.length < minValueLength) continue;
+        if (PLACEHOLDER_VALUES.has(value.toLowerCase())) continue;
+
+        // Span covers the VALUE portion only
+        const fullLine = match[0];
+        const valueStartInLine = fullLine.lastIndexOf(value);
+        const valueStart = match.index + valueStartInLine;
+
+        matches.push({
+          type: PIIType.ENV_VAR_SECRET,
+          start: valueStart,
+          end: valueStart + value.length,
+          confidence: 0.88,
+          source: DetectionSource.REGEX,
+          text: value,
+        });
+      }
+
+      return matches;
+    },
+  };
+}
+
+export const envVarSecretRecognizer = createEnvVarSecretRecognizer();

--- a/src/recognizers/secrets/index.ts
+++ b/src/recognizers/secrets/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Secret Recognizers Module
+ * Exports all secret/credential recognizers
+ */
+
+import type { Recognizer } from "../base.js";
+import { apiKeyRecognizer } from "./api-key.js";
+import { privateKeyRecognizer } from "./private-key.js";
+import { jwtRecognizer } from "./jwt.js";
+import { connectionStringRecognizer } from "./connection-string.js";
+import { awsCredentialsRecognizer } from "./aws-credentials.js";
+import { envVarSecretRecognizer } from "./env-var.js";
+import { configSecretRecognizer } from "./config-secret.js";
+
+export { apiKeyRecognizer } from "./api-key.js";
+export { privateKeyRecognizer } from "./private-key.js";
+export { jwtRecognizer } from "./jwt.js";
+export { connectionStringRecognizer } from "./connection-string.js";
+export { awsCredentialsRecognizer } from "./aws-credentials.js";
+export { envVarSecretRecognizer, createEnvVarSecretRecognizer } from "./env-var.js";
+export { configSecretRecognizer, createConfigSecretRecognizer } from "./config-secret.js";
+export { createLiteralValueRecognizer } from "./literal-value.js";
+export { isSecretKeyName } from "./key-patterns.js";
+
+/**
+ * Creates all secret recognizers
+ */
+export function createSecretRecognizers(): Recognizer[] {
+  return [
+    apiKeyRecognizer,
+    privateKeyRecognizer,
+    jwtRecognizer,
+    connectionStringRecognizer,
+    awsCredentialsRecognizer,
+    envVarSecretRecognizer,
+    configSecretRecognizer,
+  ];
+}

--- a/src/recognizers/secrets/jwt.ts
+++ b/src/recognizers/secrets/jwt.ts
@@ -1,0 +1,47 @@
+/**
+ * JWT Recognizer
+ * Detects JSON Web Tokens (three base64url dot-separated segments)
+ */
+
+import { createRegexRecognizer } from "../base.js";
+import { PIIType } from "../../types/index.js";
+
+/**
+ * Decode base64url to string (no padding required)
+ */
+function base64urlDecode(str: string): string | null {
+  try {
+    // Replace base64url chars with standard base64
+    const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+    // Add padding if needed
+    const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+    return atob(padded);
+  } catch {
+    return null;
+  }
+}
+
+export const jwtRecognizer = createRegexRecognizer({
+  type: PIIType.JWT,
+  name: "JWT",
+  defaultConfidence: 0.95,
+  patterns: [
+    // JWT: eyJ header prefix, three base64url segments separated by dots
+    /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+  ],
+  validate(match: string): boolean {
+    const parts = match.split(".");
+    if (parts.length !== 3) return false;
+
+    // Decode header and verify it has an "alg" field
+    const header = base64urlDecode(parts[0]!);
+    if (header === null) return false;
+
+    try {
+      const parsed = JSON.parse(header) as Record<string, unknown>;
+      return typeof parsed.alg === "string";
+    } catch {
+      return false;
+    }
+  },
+});

--- a/src/recognizers/secrets/key-patterns.ts
+++ b/src/recognizers/secrets/key-patterns.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared secret key name patterns
+ * Used by ENV_VAR_SECRET and CONFIG_SECRET recognizers
+ */
+
+const SECRET_KEY_PATTERN = /^(?:.*_)?(?:password|passwd|pwd|pass|secret|secret_key|secretkey|token|access_token|refresh_token|auth_token|api_key|apikey|api_secret|private_key|privatekey|credential|credentials|connection_string|connectionstring|database_url|dsn|encryption_key|signing_key|client_secret|app_secret|master_key|auth|bearer|jwt|api_token)(?:_.*)?$/i;
+
+/**
+ * Checks if a key/variable name suggests it holds a secret value.
+ * Handles snake_case, camelCase, and kebab-case.
+ */
+export function isSecretKeyName(key: string): boolean {
+  // Normalize camelCase/PascalCase to snake_case for matching
+  const normalized = key.replace(/([a-z])([A-Z])/g, "$1_$2").replace(/-/g, "_");
+  return SECRET_KEY_PATTERN.test(normalized);
+}

--- a/src/recognizers/secrets/literal-value.ts
+++ b/src/recognizers/secrets/literal-value.ts
@@ -1,0 +1,62 @@
+/**
+ * Literal Value Recognizer
+ * Scans for exact occurrences of known secret values (e.g., from .env files)
+ */
+
+import { PIIType, type SpanMatch, DetectionSource } from "../../types/index.js";
+import type { Recognizer } from "../base.js";
+
+const COMMON_NON_SECRET_VALUES = new Set([
+  "true", "false", "yes", "no", "on", "off",
+  "null", "undefined", "none",
+  "0", "1", "localhost", "127.0.0.1", "0.0.0.0",
+  "development", "production", "staging", "test",
+  "utf-8", "utf8", "ascii",
+]);
+
+/**
+ * Creates a recognizer that matches exact known secret values in text.
+ */
+export function createLiteralValueRecognizer(
+  values: string[],
+  minLength: number = 8,
+): Recognizer {
+  // Filter out short and common values
+  const secretValues = values.filter(
+    (v) => v.length >= minLength && !COMMON_NON_SECRET_VALUES.has(v.toLowerCase()),
+  );
+
+  // Sort by length descending so longer matches are found first
+  secretValues.sort((a, b) => b.length - a.length);
+
+  return {
+    type: PIIType.ENV_VAR_SECRET,
+    name: "Literal Secret Value",
+    defaultConfidence: 1.0,
+
+    find(text: string): SpanMatch[] {
+      const matches: SpanMatch[] = [];
+
+      for (const value of secretValues) {
+        let start = 0;
+        while (start < text.length) {
+          const idx = text.indexOf(value, start);
+          if (idx === -1) break;
+
+          matches.push({
+            type: PIIType.ENV_VAR_SECRET,
+            start: idx,
+            end: idx + value.length,
+            confidence: 1.0,
+            source: DetectionSource.REGEX,
+            text: value,
+          });
+
+          start = idx + value.length;
+        }
+      }
+
+      return matches;
+    },
+  };
+}

--- a/src/recognizers/secrets/private-key.ts
+++ b/src/recognizers/secrets/private-key.ts
@@ -1,0 +1,17 @@
+/**
+ * Private Key Recognizer
+ * Detects PEM-encoded private keys
+ */
+
+import { createRegexRecognizer } from "../base.js";
+import { PIIType } from "../../types/index.js";
+
+export const privateKeyRecognizer = createRegexRecognizer({
+  type: PIIType.PRIVATE_KEY,
+  name: "Private Key",
+  defaultConfidence: 0.99,
+  patterns: [
+    // Full PEM block (multiline)
+    /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----/g,
+  ],
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { PIIType, DEFAULT_TYPE_PRIORITY } from "./pii-types.js";
+import { PIIType, DEFAULT_TYPE_PRIORITY, SECRET_PII_TYPES } from "./pii-types.js";
 
 export * from "./pii-types.js";
 
@@ -218,8 +218,30 @@ export interface AnonymizationResult {
 /**
  * Creates a default anonymization policy with all types enabled
  */
+/**
+ * Secrets/credentials detection configuration
+ */
+export interface SecretsConfig {
+  /** Enable secrets/credentials detection */
+  enabled: boolean;
+  /** .env file paths to parse for known secret values */
+  envFiles?: string[];
+  /** Explicit values to always redact */
+  redactValues?: string[];
+  /** Additional key name patterns for ENV_VAR_SECRET / CONFIG_SECRET detection */
+  secretKeyPatterns?: RegExp[];
+  /** Minimum value length to consider as a secret (default: 8) */
+  minValueLength?: number;
+}
+
 export function createDefaultPolicy(): AnonymizationPolicy {
   const allTypes = new Set(Object.values(PIIType) as PIIType[]);
+
+  // Secret types are opt-in only — exclude from default enabled set
+  const secretTypeSet = new Set<PIIType>(SECRET_PII_TYPES);
+  for (const secretType of secretTypeSet) {
+    allTypes.delete(secretType);
+  }
 
   const defaultThresholds = new Map<PIIType, number>();
   for (const type of allTypes) {

--- a/src/types/pii-types.ts
+++ b/src/types/pii-types.ts
@@ -29,6 +29,15 @@ export enum PIIType {
   // Custom/Business identifiers
   CASE_ID = 'CASE_ID',
   CUSTOMER_ID = 'CUSTOMER_ID',
+
+  // Secrets/Credentials
+  API_KEY = 'API_KEY',
+  PRIVATE_KEY = 'PRIVATE_KEY',
+  JWT = 'JWT',
+  CONNECTION_STRING = 'CONNECTION_STRING',
+  AWS_CREDENTIALS = 'AWS_CREDENTIALS',
+  ENV_VAR_SECRET = 'ENV_VAR_SECRET',
+  CONFIG_SECRET = 'CONFIG_SECRET',
 }
 
 /**
@@ -52,6 +61,19 @@ export const REGEX_PII_TYPES: readonly PIIType[] = [
   PIIType.NATIONAL_ID,
   PIIType.CASE_ID,
   PIIType.CUSTOMER_ID,
+];
+
+/**
+ * PII types that are secrets/credentials (opt-in, regex-based)
+ */
+export const SECRET_PII_TYPES: readonly PIIType[] = [
+  PIIType.API_KEY,
+  PIIType.PRIVATE_KEY,
+  PIIType.JWT,
+  PIIType.CONNECTION_STRING,
+  PIIType.AWS_CREDENTIALS,
+  PIIType.ENV_VAR_SECRET,
+  PIIType.CONFIG_SECRET,
 ];
 
 /**
@@ -90,6 +112,14 @@ export const DEFAULT_TYPE_PRIORITY: readonly PIIType[] = [
   PIIType.CREDIT_CARD,
   PIIType.TAX_ID,
   PIIType.NATIONAL_ID,
+  // Highest priority (secrets/credentials)
+  PIIType.ENV_VAR_SECRET,
+  PIIType.CONFIG_SECRET,
+  PIIType.CONNECTION_STRING,
+  PIIType.AWS_CREDENTIALS,
+  PIIType.API_KEY,
+  PIIType.PRIVATE_KEY,
+  PIIType.JWT,
 ];
 
 /**

--- a/test/integration/secrets.test.ts
+++ b/test/integration/secrets.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  createAnonymizer,
+  PIIType,
+  InMemoryKeyProvider,
+} from "../../src/index.js";
+import type { Anonymizer } from "../../src/index.js";
+
+describe("Secrets Detection Integration", () => {
+  let anonymizer: Anonymizer;
+
+  afterEach(async () => {
+    if (anonymizer) {
+      await anonymizer.dispose();
+    }
+  });
+
+  it("should not detect secrets when disabled (default)", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({ keyProvider });
+    await anonymizer.initialize();
+
+    const text = "My API key is sk-proj-abcdefghij1234567890abcd";
+    const result = await anonymizer.anonymize(text);
+
+    const apiKeyEntities = result.entities.filter(
+      (e) => e.type === PIIType.API_KEY
+    );
+    expect(apiKeyEntities).toHaveLength(0);
+    expect(result.stats.countsByType[PIIType.API_KEY] ?? 0).toBe(0);
+  });
+
+  it("should detect API keys when secrets enabled", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({
+      keyProvider,
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text = "My API key is sk-proj-abcdefghij1234567890abcd";
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="API_KEY"');
+    expect(result.anonymizedText).not.toContain(
+      "sk-proj-abcdefghij1234567890abcd"
+    );
+    expect(result.stats.countsByType[PIIType.API_KEY]).toBe(1);
+    expect(result.entities.some((e) => e.type === PIIType.API_KEY)).toBe(true);
+  });
+
+  it("should detect JWT tokens when secrets enabled", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({
+      keyProvider,
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text =
+      "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="JWT"');
+    expect(result.stats.countsByType[PIIType.JWT]).toBe(1);
+    expect(result.entities.some((e) => e.type === PIIType.JWT)).toBe(true);
+  });
+
+  it("should detect connection strings", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({
+      keyProvider,
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text =
+      "Database URL: postgres://admin:hunter2secret@db.example.com/myapp";
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="CONNECTION_STRING"');
+    expect(result.anonymizedText).not.toContain(
+      "postgres://admin:hunter2secret@db.example.com/myapp"
+    );
+    expect(result.stats.countsByType[PIIType.CONNECTION_STRING]).toBe(1);
+    expect(
+      result.entities.some((e) => e.type === PIIType.CONNECTION_STRING)
+    ).toBe(true);
+  });
+
+  it("should detect AWS access keys", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({
+      keyProvider,
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text = "AWS key: AKIAIOSFODNN7EXAMPLE";
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="AWS_CREDENTIALS"');
+    expect(result.anonymizedText).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(result.stats.countsByType[PIIType.AWS_CREDENTIALS]).toBe(1);
+    expect(
+      result.entities.some((e) => e.type === PIIType.AWS_CREDENTIALS)
+    ).toBe(true);
+  });
+
+  it("should detect env var secrets", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({
+      keyProvider,
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text = "DATABASE_PASSWORD=supersecretvalue123";
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="ENV_VAR_SECRET"');
+    expect(result.anonymizedText).not.toContain(
+      "DATABASE_PASSWORD=supersecretvalue123"
+    );
+    expect(result.stats.countsByType[PIIType.ENV_VAR_SECRET]).toBe(1);
+    expect(
+      result.entities.some((e) => e.type === PIIType.ENV_VAR_SECRET)
+    ).toBe(true);
+  });
+
+  it("should detect config secrets in JSON", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({
+      keyProvider,
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text = '{"api_key": "sk-realkey-abcdefghij1234567890"}';
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="CONFIG_SECRET"');
+    expect(result.anonymizedText).not.toContain(
+      "sk-realkey-abcdefghij1234567890"
+    );
+    expect(result.stats.countsByType[PIIType.CONFIG_SECRET]).toBe(1);
+    expect(
+      result.entities.some((e) => e.type === PIIType.CONFIG_SECRET)
+    ).toBe(true);
+  });
+
+  it("should detect PEM private keys", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({
+      keyProvider,
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text = [
+      "Here is the key:",
+      "-----BEGIN PRIVATE KEY-----",
+      "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7",
+      "-----END PRIVATE KEY-----",
+    ].join("\n");
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="PRIVATE_KEY"');
+    expect(result.anonymizedText).not.toContain("BEGIN PRIVATE KEY");
+    expect(result.stats.countsByType[PIIType.PRIVATE_KEY]).toBe(1);
+    expect(result.entities.some((e) => e.type === PIIType.PRIVATE_KEY)).toBe(
+      true
+    );
+  });
+
+  it("should detect secrets alongside regular PII", async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    anonymizer = createAnonymizer({
+      keyProvider,
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text =
+      "Contact support@example.com with key sk-proj-abcdefghij1234567890abcd";
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="EMAIL"');
+    expect(result.anonymizedText).toContain('<PII type="API_KEY"');
+    expect(result.anonymizedText).not.toContain("support@example.com");
+    expect(result.anonymizedText).not.toContain(
+      "sk-proj-abcdefghij1234567890abcd"
+    );
+    expect(result.stats.countsByType[PIIType.EMAIL]).toBe(1);
+    expect(result.stats.countsByType[PIIType.API_KEY]).toBe(1);
+    expect(result.stats.totalEntities).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should work with anonymize mode (irreversible)", async () => {
+    anonymizer = createAnonymizer({
+      mode: "anonymize",
+      secrets: { enabled: true },
+    });
+    await anonymizer.initialize();
+
+    const text = "My key is sk-proj-abcdefghij1234567890abcd";
+    const result = await anonymizer.anonymize(text);
+
+    expect(result.anonymizedText).toContain('<PII type="API_KEY"');
+    expect(result.anonymizedText).not.toContain(
+      "sk-proj-abcdefghij1234567890abcd"
+    );
+    expect(result.piiMap).toBeUndefined();
+    expect(result.stats.countsByType[PIIType.API_KEY]).toBe(1);
+  });
+});

--- a/test/recognizers/secrets/api-key.test.ts
+++ b/test/recognizers/secrets/api-key.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { apiKeyRecognizer } from '../../../src/recognizers/secrets/api-key.js';
+import { PIIType, DetectionSource } from '../../../src/types/index.js';
+
+describe('API Key Recognizer', () => {
+  describe('find', () => {
+    it('should detect OpenAI keys (sk-proj-)', () => {
+      const text = 'My key is sk-proj-abcdefghij1234567890abcd';
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.API_KEY,
+        text: 'sk-proj-abcdefghij1234567890abcd',
+        source: DetectionSource.REGEX,
+      });
+    });
+
+    it('should detect OpenAI keys (sk- generic)', () => {
+      const text = 'Use sk-abcdefghij1234567890abcd for the API';
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const found = matches.some((m) => m.text.startsWith('sk-'));
+      expect(found).toBe(true);
+    });
+
+    it('should detect Anthropic keys', () => {
+      const text = 'Set ANTHROPIC_API_KEY=sk-ant-api03-abcdefghij1234567890';
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const found = matches.some((m) => m.text.startsWith('sk-ant-'));
+      expect(found).toBe(true);
+    });
+
+    it('should detect GitHub PATs', () => {
+      const text = 'token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh1234';
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.API_KEY,
+        text: 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh1234',
+      });
+    });
+
+    it('should detect Stripe keys', () => {
+      // Build key dynamically to avoid GitHub push protection
+      const prefix = ['sk', 'test'].join('_') + '_';
+      const text = `STRIPE_KEY=${prefix}${'X'.repeat(24)}`;
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const found = matches.some((m) => m.text.startsWith(prefix));
+      expect(found).toBe(true);
+    });
+
+    it('should detect Slack tokens', () => {
+      const text = 'SLACK_TOKEN=xoxb-1234567890-abcdefghij';
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const found = matches.some((m) => m.text.startsWith('xoxb-'));
+      expect(found).toBe(true);
+    });
+
+    it('should detect SendGrid keys', () => {
+      // SendGrid pattern: SG. + 22 base64url chars + . + 43 base64url chars
+      const sgKey = 'SG.FAKE_FAKE_FAKE_FAKE_FA.FAKE_FAKE_FAKE_FAKE_FAKE_FAKE_FAKE_FAKE_FAK';
+      const text = `SENDGRID=${sgKey}`;
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.API_KEY,
+        text: sgKey,
+      });
+    });
+
+    it('should not match short strings like sk-short', () => {
+      const text = 'This sk-short is not a real key';
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should not match normal words', () => {
+      const text = 'The skeleton was found in the closet yesterday';
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should not match variable names', () => {
+      const text = 'const apiKey = getApiKey()';
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should provide correct offsets', () => {
+      const key = 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh1234';
+      const text = `Token: ${key} is valid`;
+      const matches = apiKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.start).toBe(7);
+      expect(matches[0]?.end).toBe(7 + key.length);
+      expect(text.slice(matches[0]!.start, matches[0]!.end)).toBe(key);
+    });
+  });
+
+  describe('validate', () => {
+    it('should reject Heroku-style UUIDs', () => {
+      expect(apiKeyRecognizer.validate!('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(false);
+    });
+
+    it('should reject strings shorter than 20 characters', () => {
+      expect(apiKeyRecognizer.validate!('sk-short')).toBe(false);
+    });
+
+    it('should accept valid API key patterns', () => {
+      expect(apiKeyRecognizer.validate!('sk-proj-abcdefghij1234567890abcd')).toBe(true);
+    });
+  });
+});

--- a/test/recognizers/secrets/aws-credentials.test.ts
+++ b/test/recognizers/secrets/aws-credentials.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { awsCredentialsRecognizer } from '../../../src/recognizers/secrets/aws-credentials.js';
+import { PIIType, DetectionSource } from '../../../src/types/index.js';
+
+describe('AWS Credentials Recognizer', () => {
+  describe('find', () => {
+    it('should detect AKIA access keys', () => {
+      const text = 'aws_access_key_id = AKIAIOSFODNN7EXAMPLE';
+      const matches = awsCredentialsRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const akiaMatch = matches.find((m) => m.text === 'AKIAIOSFODNN7EXAMPLE');
+      expect(akiaMatch).toBeDefined();
+      expect(akiaMatch).toMatchObject({
+        type: PIIType.AWS_CREDENTIALS,
+        text: 'AKIAIOSFODNN7EXAMPLE',
+        source: DetectionSource.REGEX,
+      });
+    });
+
+    it('should detect AKIA keys without surrounding context', () => {
+      const text = 'Key: AKIAIOSFODNN7EXAMPLE';
+      const matches = awsCredentialsRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toBe('AKIAIOSFODNN7EXAMPLE');
+    });
+
+    it('should detect secret keys when context keyword is present', () => {
+      const text = 'aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+      const matches = awsCredentialsRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const secretMatch = matches.find(
+        (m) => m.text === 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      );
+      expect(secretMatch).toBeDefined();
+      expect(secretMatch).toMatchObject({
+        type: PIIType.AWS_CREDENTIALS,
+        source: DetectionSource.REGEX,
+      });
+    });
+
+    it('should NOT detect 40-char base64 strings without AWS context', () => {
+      // This text has no AWS-related keywords
+      const text = 'random_value = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+      const matches = awsCredentialsRecognizer.find(text);
+
+      // Should not find the 40-char string because there is no aws_secret context
+      const secretMatch = matches.find(
+        (m) => m.text === 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      );
+      expect(secretMatch).toBeUndefined();
+    });
+
+    it('should detect both access key and secret key in the same text', () => {
+      const text = `aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`;
+      const matches = awsCredentialsRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+      const akiaMatch = matches.find((m) => m.text.startsWith('AKIA'));
+      const secretMatch = matches.find((m) => m.text.includes('/'));
+      expect(akiaMatch).toBeDefined();
+      expect(secretMatch).toBeDefined();
+    });
+
+    it('should provide correct offsets for AKIA keys', () => {
+      const key = 'AKIAIOSFODNN7EXAMPLE';
+      const text = `ID: ${key} here`;
+      const matches = awsCredentialsRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.start).toBe(4);
+      expect(matches[0]?.end).toBe(4 + key.length);
+      expect(text.slice(matches[0]!.start, matches[0]!.end)).toBe(key);
+    });
+  });
+
+  describe('validate', () => {
+    it('should validate AKIA access keys', () => {
+      expect(awsCredentialsRecognizer.validate!('AKIAIOSFODNN7EXAMPLE')).toBe(true);
+    });
+
+    it('should validate 40-char secret keys', () => {
+      expect(
+        awsCredentialsRecognizer.validate!('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'),
+      ).toBe(true);
+    });
+
+    it('should reject keys that are not 20 or 40 chars', () => {
+      expect(awsCredentialsRecognizer.validate!('AKIA_SHORT')).toBe(false);
+      expect(awsCredentialsRecognizer.validate!('abcdef')).toBe(false);
+    });
+  });
+});

--- a/test/recognizers/secrets/config-secret.test.ts
+++ b/test/recognizers/secrets/config-secret.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  configSecretRecognizer,
+  createConfigSecretRecognizer,
+} from '../../../src/recognizers/secrets/config-secret.js';
+import { PIIType, DetectionSource } from '../../../src/types/index.js';
+
+describe('Config Secret Recognizer', () => {
+  describe('find', () => {
+    it('should detect JSON secrets', () => {
+      const text = '"password": "s3cret_hunter2"';
+      const matches = configSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.CONFIG_SECRET,
+        text: 's3cret_hunter2',
+        source: DetectionSource.REGEX,
+      });
+    });
+
+    it('should detect YAML secrets', () => {
+      const text = 'api_token: s3cret_hunter2_value';
+      const matches = configSecretRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const match = matches.find((m) => m.text.includes('s3cret_hunter2_value'));
+      expect(match).toBeDefined();
+      expect(match).toMatchObject({
+        type: PIIType.CONFIG_SECRET,
+      });
+    });
+
+    it('should detect TOML secrets', () => {
+      const text = 'secret_key = "s3cret_hunter2"';
+      const matches = configSecretRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const match = matches.find((m) => m.text === 's3cret_hunter2');
+      expect(match).toBeDefined();
+    });
+
+    it('should NOT detect non-secret keys', () => {
+      const text = '"name": "John Smith"';
+      const matches = configSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should NOT detect short values', () => {
+      const text = '"password": "abc"';
+      const matches = configSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should detect secrets in multiline JSON config', () => {
+      const text = `{
+  "host": "db.example.com",
+  "password": "super-s3cret-pass",
+  "port": 5432
+}`;
+      const matches = configSecretRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const pwMatch = matches.find((m) => m.text === 'super-s3cret-pass');
+      expect(pwMatch).toBeDefined();
+    });
+
+    it('should detect secrets in multiline YAML config', () => {
+      const text = `database:
+  host: db.example.com
+  password: super-s3cret-pass
+  port: 5432`;
+      const matches = configSecretRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const pwMatch = matches.find((m) => m.text.includes('super-s3cret-pass'));
+      expect(pwMatch).toBeDefined();
+    });
+
+    it('should provide correct offsets (value only)', () => {
+      const text = '"api_secret": "my_secret_value_123"';
+      const matches = configSecretRecognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const match = matches.find((m) => m.text === 'my_secret_value_123');
+      expect(match).toBeDefined();
+      expect(text.slice(match!.start, match!.end)).toBe('my_secret_value_123');
+    });
+  });
+
+  describe('createConfigSecretRecognizer', () => {
+    it('should respect custom minValueLength', () => {
+      const recognizer = createConfigSecretRecognizer(20);
+      const text = '"password": "short1234"';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should support extra key patterns', () => {
+      const recognizer = createConfigSecretRecognizer(8, [/^my_custom_/i]);
+      const text = '"my_custom_field": "this-is-a-custom-secret"';
+      const matches = recognizer.find(text);
+
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+      const match = matches.find((m) => m.text === 'this-is-a-custom-secret');
+      expect(match).toBeDefined();
+    });
+  });
+});

--- a/test/recognizers/secrets/connection-string.test.ts
+++ b/test/recognizers/secrets/connection-string.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { connectionStringRecognizer } from '../../../src/recognizers/secrets/connection-string.js';
+import { PIIType, DetectionSource } from '../../../src/types/index.js';
+
+describe('Connection String Recognizer', () => {
+  describe('find', () => {
+    it('should detect postgres connection strings', () => {
+      const text = 'DATABASE_URL=postgres://admin:s3cretP4ss@db.example.com:5432/mydb';
+      const matches = connectionStringRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.CONNECTION_STRING,
+        source: DetectionSource.REGEX,
+      });
+      expect(matches[0]?.text).toContain('postgres://admin:s3cretP4ss@');
+    });
+
+    it('should detect postgresql connection strings', () => {
+      const text = 'url = postgresql://user:hunter2hunt@localhost/testdb';
+      const matches = connectionStringRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toContain('postgresql://');
+    });
+
+    it('should detect mongodb+srv connection strings', () => {
+      const text = 'MONGO_URI=mongodb+srv://dbuser:MyP4ssw0rd@cluster0.mongodb.net/app';
+      const matches = connectionStringRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toContain('mongodb+srv://');
+    });
+
+    it('should detect redis connection strings', () => {
+      const text = 'REDIS_URL=redis://default:r3disP4ss@redis.example.com:6379';
+      const matches = connectionStringRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toContain('redis://');
+    });
+
+    it('should detect mysql connection strings', () => {
+      const text = 'mysql://root:mySqlP4ss@db-host.example.com/production';
+      const matches = connectionStringRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toContain('mysql://');
+    });
+
+    it('should not match URIs without credentials', () => {
+      const texts = [
+        'postgres://host/db',
+        'redis://localhost:6379',
+        'mongodb://host/db',
+      ];
+
+      for (const text of texts) {
+        const matches = connectionStringRecognizer.find(text);
+        expect(matches).toHaveLength(0);
+      }
+    });
+
+    it('should provide correct offsets', () => {
+      const connStr = 'postgres://admin:s3cretP4ss@db.example.com/mydb';
+      const text = `URL: ${connStr} end`;
+      const matches = connectionStringRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.start).toBe(5);
+      expect(text.slice(matches[0]!.start, matches[0]!.end)).toBe(connStr);
+    });
+  });
+
+  describe('validate', () => {
+    it('should reject placeholder passwords', () => {
+      expect(connectionStringRecognizer.validate!('postgres://user:password@host/db')).toBe(false);
+      expect(connectionStringRecognizer.validate!('postgres://user:changeme@host/db')).toBe(false);
+      expect(connectionStringRecognizer.validate!('postgres://user:secret@host/db')).toBe(false);
+    });
+
+    it('should reject very short passwords', () => {
+      expect(connectionStringRecognizer.validate!('postgres://user:ab@host/db')).toBe(false);
+    });
+
+    it('should accept real-looking passwords', () => {
+      expect(connectionStringRecognizer.validate!('postgres://user:s3cretP4ss@host/db')).toBe(true);
+    });
+
+    it('should reject strings without credentials pattern', () => {
+      expect(connectionStringRecognizer.validate!('postgres://host/db')).toBe(false);
+    });
+  });
+});

--- a/test/recognizers/secrets/env-var.test.ts
+++ b/test/recognizers/secrets/env-var.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  envVarSecretRecognizer,
+  createEnvVarSecretRecognizer,
+} from '../../../src/recognizers/secrets/env-var.js';
+import { PIIType, DetectionSource } from '../../../src/types/index.js';
+
+describe('Env Var Secret Recognizer', () => {
+  describe('find', () => {
+    it('should detect DATABASE_PASSWORD with long value (value only span)', () => {
+      const text = 'DATABASE_PASSWORD=hunter2hunter2';
+      const matches = envVarSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.ENV_VAR_SECRET,
+        text: 'hunter2hunter2',
+        source: DetectionSource.REGEX,
+      });
+    });
+
+    it('should detect export API_KEY=<value>', () => {
+      const text = 'export API_KEY=sk-1234567890abcdef';
+      const matches = envVarSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.ENV_VAR_SECRET,
+        text: 'sk-1234567890abcdef',
+      });
+    });
+
+    it('should detect secret in quoted values', () => {
+      const text = 'AUTH_TOKEN="my-super-secret-token-value"';
+      const matches = envVarSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toBe('my-super-secret-token-value');
+    });
+
+    it('should NOT detect short values', () => {
+      const text = 'PASSWORD=abc';
+      const matches = envVarSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should NOT detect non-secret keys', () => {
+      const text = 'NODE_ENV=production';
+      const matches = envVarSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should NOT detect placeholder values', () => {
+      const text = 'API_KEY=changeme';
+      const matches = envVarSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should NOT detect other placeholder values', () => {
+      const placeholders = [
+        'SECRET=your-api-key-here',
+        'TOKEN=your_api_key_here',
+        'PASSWORD=placeholder',
+        'API_KEY=replace_me',
+      ];
+
+      for (const text of placeholders) {
+        const matches = envVarSecretRecognizer.find(text);
+        expect(matches).toHaveLength(0);
+      }
+    });
+
+    it('should detect multiple env var secrets in multiline text', () => {
+      const text = `DATABASE_PASSWORD=hunter2hunter2
+API_KEY=sk-1234567890abcdef
+NODE_ENV=production`;
+      const matches = envVarSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(2);
+    });
+
+    it('should provide correct offsets (value only)', () => {
+      const text = 'SECRET_KEY=mysecretvalue12345';
+      const matches = envVarSecretRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      const value = 'mysecretvalue12345';
+      expect(matches[0]?.text).toBe(value);
+      expect(text.slice(matches[0]!.start, matches[0]!.end)).toBe(value);
+    });
+  });
+
+  describe('createEnvVarSecretRecognizer', () => {
+    it('should respect custom minValueLength', () => {
+      const recognizer = createEnvVarSecretRecognizer(20);
+      const text = 'PASSWORD=short1234';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should support extra key patterns', () => {
+      const recognizer = createEnvVarSecretRecognizer(8, [/^MY_CUSTOM_/i]);
+      const text = 'MY_CUSTOM_FIELD=this-is-a-long-value-here';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toBe('this-is-a-long-value-here');
+    });
+  });
+});

--- a/test/recognizers/secrets/jwt.test.ts
+++ b/test/recognizers/secrets/jwt.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { jwtRecognizer } from '../../../src/recognizers/secrets/jwt.js';
+import { PIIType, DetectionSource } from '../../../src/types/index.js';
+
+describe('JWT Recognizer', () => {
+  const validJwt =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+
+  describe('find', () => {
+    it('should detect a valid JWT', () => {
+      const text = `Bearer ${validJwt}`;
+      const matches = jwtRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.JWT,
+        text: validJwt,
+        source: DetectionSource.REGEX,
+      });
+    });
+
+    it('should detect JWT in a longer text', () => {
+      const text = `The token is ${validJwt} and it expires soon.`;
+      const matches = jwtRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toBe(validJwt);
+    });
+
+    it('should not match random base64 strings', () => {
+      const text = 'Here is some base64: dGVzdGluZzEyMw== and more text';
+      const matches = jwtRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should not match partial JWTs with missing segment', () => {
+      // Only two segments instead of three
+      const text = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0';
+      const matches = jwtRecognizer.find(text);
+
+      // The regex requires three dot-separated segments, so this should not match
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should not match strings that do not start with eyJ', () => {
+      const text = 'abc.def.ghi is not a JWT';
+      const matches = jwtRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should provide correct offsets', () => {
+      const prefix = 'Authorization: Bearer ';
+      const text = `${prefix}${validJwt}`;
+      const matches = jwtRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.start).toBe(prefix.length);
+      expect(matches[0]?.end).toBe(prefix.length + validJwt.length);
+      expect(text.slice(matches[0]!.start, matches[0]!.end)).toBe(validJwt);
+    });
+
+    it('should detect multiple JWTs in the same text', () => {
+      const text = `First: ${validJwt} Second: ${validJwt}`;
+      const matches = jwtRecognizer.find(text);
+
+      expect(matches).toHaveLength(2);
+    });
+  });
+
+  describe('validate', () => {
+    it('should verify alg field in header', () => {
+      expect(jwtRecognizer.validate!(validJwt)).toBe(true);
+    });
+
+    it('should reject JWT with missing alg in header', () => {
+      // eyJ0eXAiOiJKV1QifQ == {"typ":"JWT"} (no alg)
+      const noAlg = 'eyJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcdefghijklmno';
+      expect(jwtRecognizer.validate!(noAlg)).toBe(false);
+    });
+
+    it('should reject non-JSON header', () => {
+      // Random base64url that does not decode to valid JSON
+      const invalid = 'eyJpbnZhbGlk.eyJzdWIiOiIxMjM0In0.abcdefghijklmno';
+      // This may or may not parse depending on padding; if it does parse,
+      // it lacks an alg field
+      const result = jwtRecognizer.validate!(invalid);
+      // Either it fails to parse JSON (false) or it has no alg (false)
+      expect(result).toBe(false);
+    });
+
+    it('should reject string that is not three segments', () => {
+      expect(jwtRecognizer.validate!('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0')).toBe(false);
+    });
+  });
+});

--- a/test/recognizers/secrets/literal-value.test.ts
+++ b/test/recognizers/secrets/literal-value.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { createLiteralValueRecognizer } from '../../../src/recognizers/secrets/literal-value.js';
+import { PIIType, DetectionSource } from '../../../src/types/index.js';
+
+describe('Literal Value Recognizer', () => {
+  describe('find', () => {
+    it('should find exact value occurrences in text', () => {
+      const recognizer = createLiteralValueRecognizer(['my-secret-value-1234']);
+      const text = 'The config contains my-secret-value-1234 as the key.';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.ENV_VAR_SECRET,
+        text: 'my-secret-value-1234',
+        source: DetectionSource.REGEX,
+      });
+    });
+
+    it('should filter out short values', () => {
+      const recognizer = createLiteralValueRecognizer(['short', 'ab', 'my-long-secret-value']);
+      const text = 'short ab my-long-secret-value';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toBe('my-long-secret-value');
+    });
+
+    it('should filter out common values', () => {
+      const recognizer = createLiteralValueRecognizer([
+        'true',
+        'false',
+        'localhost',
+        'production',
+        'development',
+        'my-actual-secret-12',
+      ]);
+      const text = 'true false localhost production development my-actual-secret-12';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toBe('my-actual-secret-12');
+    });
+
+    it('should handle multiple occurrences of the same value', () => {
+      const recognizer = createLiteralValueRecognizer(['secret-token-value1']);
+      const text = 'first: secret-token-value1, second: secret-token-value1';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0]?.text).toBe('secret-token-value1');
+      expect(matches[1]?.text).toBe('secret-token-value1');
+    });
+
+    it('should have correct offsets', () => {
+      const value = 'super-secret-password-123';
+      const recognizer = createLiteralValueRecognizer([value]);
+      const text = `Key: ${value} done`;
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.start).toBe(5);
+      expect(matches[0]?.end).toBe(5 + value.length);
+      expect(text.slice(matches[0]!.start, matches[0]!.end)).toBe(value);
+    });
+
+    it('should respect custom minLength', () => {
+      const recognizer = createLiteralValueRecognizer(['abcde12345'], 12);
+      const text = 'value: abcde12345';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should find multiple different values', () => {
+      const recognizer = createLiteralValueRecognizer([
+        'first-secret-value-1',
+        'second-secret-value2',
+      ]);
+      const text = 'A: first-secret-value-1, B: second-secret-value2';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(2);
+    });
+
+    it('should return empty array for no values provided', () => {
+      const recognizer = createLiteralValueRecognizer([]);
+      const text = 'some text with nothing to find';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should have confidence of 1.0', () => {
+      const recognizer = createLiteralValueRecognizer(['known-secret-val-12']);
+      const text = 'the known-secret-val-12 here';
+      const matches = recognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.confidence).toBe(1.0);
+    });
+  });
+});

--- a/test/recognizers/secrets/private-key.test.ts
+++ b/test/recognizers/secrets/private-key.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { privateKeyRecognizer } from '../../../src/recognizers/secrets/private-key.js';
+import { PIIType, DetectionSource } from '../../../src/types/index.js';
+
+describe('Private Key Recognizer', () => {
+  describe('find', () => {
+    it('should detect RSA private key PEM blocks', () => {
+      const text = `Here is a key:
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA0Z3VS5JJcds3xfn/yGaXm2LBQJ+bLiE8MFQqVEBbGhOC0mI
+hP8R1F6epMjAwnSaL3KMH1FaKE0VTDx3z6ywqXbWQJB7XHZQ1UqKRPRBDkX
+-----END RSA PRIVATE KEY-----
+That was the key.`;
+      const matches = privateKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.PRIVATE_KEY,
+        source: DetectionSource.REGEX,
+      });
+      expect(matches[0]?.text).toContain('-----BEGIN RSA PRIVATE KEY-----');
+      expect(matches[0]?.text).toContain('-----END RSA PRIVATE KEY-----');
+    });
+
+    it('should detect EC private key PEM blocks', () => {
+      const text = `-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIODsdVh5J4AgWmJFLz3CBs0kxBBQqtjRg8b5MT+HpvL6oAcGBSuBBAAi
+oWQDYgAEMuxBBOV7S0JaRqhPDy0u2Po1N9aTIuNyFTlqJXX8Gw3E1b
+-----END EC PRIVATE KEY-----`;
+      const matches = privateKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.PRIVATE_KEY,
+      });
+      expect(matches[0]?.text).toContain('-----BEGIN EC PRIVATE KEY-----');
+      expect(matches[0]?.text).toContain('-----END EC PRIVATE KEY-----');
+    });
+
+    it('should detect OPENSSH private key PEM blocks', () => {
+      const text = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBt1Y3FbCw0UKNpyGkRjDmZmFSq/qMEdS/lSN0Dp1gQ
+-----END OPENSSH PRIVATE KEY-----`;
+      const matches = privateKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        type: PIIType.PRIVATE_KEY,
+      });
+      expect(matches[0]?.text).toContain('-----BEGIN OPENSSH PRIVATE KEY-----');
+      expect(matches[0]?.text).toContain('-----END OPENSSH PRIVATE KEY-----');
+    });
+
+    it('should detect generic private key PEM blocks', () => {
+      const text = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC7cn6lHfKJ1wfk
+-----END PRIVATE KEY-----`;
+      const matches = privateKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toContain('-----BEGIN PRIVATE KEY-----');
+      expect(matches[0]?.text).toContain('-----END PRIVATE KEY-----');
+    });
+
+    it('should not detect public key blocks', () => {
+      const text = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn
+-----END PUBLIC KEY-----`;
+      const matches = privateKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should not detect certificate blocks', () => {
+      const text = `-----BEGIN CERTIFICATE-----
+MIIDXTCCAkWgAwIBAgIJAJC1HiIAZAiUMA0Gcz6E8JU3OQ==
+-----END CERTIFICATE-----`;
+      const matches = privateKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should handle multiline keys correctly', () => {
+      const text = `Config:
+-----BEGIN RSA PRIVATE KEY-----
+AAAA
+BBBB
+CCCC
+DDDD
+-----END RSA PRIVATE KEY-----
+Done.`;
+      const matches = privateKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.text).toContain('AAAA');
+      expect(matches[0]?.text).toContain('DDDD');
+    });
+
+    it('should detect multiple private keys in the same text', () => {
+      const text = `-----BEGIN RSA PRIVATE KEY-----
+AAAA1111
+-----END RSA PRIVATE KEY-----
+some text in between
+-----BEGIN EC PRIVATE KEY-----
+BBBB2222
+-----END EC PRIVATE KEY-----`;
+      const matches = privateKeyRecognizer.find(text);
+
+      expect(matches).toHaveLength(2);
+    });
+  });
+});

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -147,13 +147,24 @@ describe("DetectionSource", () => {
 });
 
 describe("createDefaultPolicy", () => {
-  it("should create a policy with all types enabled", () => {
+  it("should create a policy with all non-secret types enabled", () => {
     const policy = createDefaultPolicy();
 
-    expect(policy.enabledTypes.size).toBe(Object.values(PIIType).length);
-    for (const type of Object.values(PIIType)) {
-      expect(policy.enabledTypes.has(type)).toBe(true);
-    }
+    // Secret types should NOT be enabled by default (opt-in only)
+    expect(policy.enabledTypes.has(PIIType.API_KEY)).toBe(false);
+    expect(policy.enabledTypes.has(PIIType.PRIVATE_KEY)).toBe(false);
+    expect(policy.enabledTypes.has(PIIType.JWT)).toBe(false);
+    expect(policy.enabledTypes.has(PIIType.CONNECTION_STRING)).toBe(false);
+    expect(policy.enabledTypes.has(PIIType.AWS_CREDENTIALS)).toBe(false);
+    expect(policy.enabledTypes.has(PIIType.ENV_VAR_SECRET)).toBe(false);
+    expect(policy.enabledTypes.has(PIIType.CONFIG_SECRET)).toBe(false);
+
+    // All non-secret types should be enabled
+    expect(policy.enabledTypes.has(PIIType.EMAIL)).toBe(true);
+    expect(policy.enabledTypes.has(PIIType.PERSON)).toBe(true);
+    expect(policy.enabledTypes.has(PIIType.PHONE)).toBe(true);
+    expect(policy.enabledTypes.has(PIIType.IBAN)).toBe(true);
+    expect(policy.enabledTypes.size).toBe(17);
   });
 
   it("should have correct regex-enabled types", () => {


### PR DESCRIPTION
## Summary
- Adds 7 new `PIIType` values: `API_KEY`, `PRIVATE_KEY`, `JWT`, `CONNECTION_STRING`, `AWS_CREDENTIALS`, `ENV_VAR_SECRET`, `CONFIG_SECRET`
- Opt-in via `secrets: { enabled: true }` in `AnonymizerConfig` — disabled by default, no impact on existing users
- Pattern-based recognizers for OpenAI, Anthropic, GitHub, Stripe, Slack, SendGrid, Twilio API keys, PEM private keys, JWTs (with header validation), database connection strings, and AWS credentials
- Context-dependent recognizers for `.env` file secrets and JSON/YAML/TOML config secrets (key-name heuristics)
- `.env` file parsing for literal value redaction via `secrets.envFiles`
- CLI `--secrets` and `--env-file` flags for `anonymize` and `inspect` commands

Closes #23

## Test plan
- [x] 1190 tests pass (93 new across 9 test files)
- [x] Build clean
- [x] Existing 1097 tests unaffected (secrets disabled by default)
- [x] Integration test verifies end-to-end: secrets enabled detects all 7 types, secrets disabled detects none