### PR TITLE
Wire SecretsConfig options to all secret recognizers

### DIFF
--- a/src/core/anonymizer.ts
+++ b/src/core/anonymizer.ts
@@ -342,7 +342,10 @@ export class Anonymizer {
       };
 
       // Register secret recognizers
-      for (const recognizer of createSecretRecognizers()) {
+      for (const recognizer of createSecretRecognizers({
+        secretKeyPatterns: this.secretsConfig.secretKeyPatterns,
+        minValueLength: this.secretsConfig.minValueLength,
+      })) {
         this.registry.register(recognizer);
       }
     }

--- a/src/recognizers/secrets/index.ts
+++ b/src/recognizers/secrets/index.ts
@@ -9,8 +9,8 @@ import { privateKeyRecognizer } from "./private-key.js";
 import { jwtRecognizer } from "./jwt.js";
 import { connectionStringRecognizer } from "./connection-string.js";
 import { awsCredentialsRecognizer } from "./aws-credentials.js";
-import { envVarSecretRecognizer } from "./env-var.js";
-import { configSecretRecognizer } from "./config-secret.js";
+import { envVarSecretRecognizer, createEnvVarSecretRecognizer } from "./env-var.js";
+import { configSecretRecognizer, createConfigSecretRecognizer } from "./config-secret.js";
 
 export { apiKeyRecognizer } from "./api-key.js";
 export { privateKeyRecognizer } from "./private-key.js";
@@ -25,14 +25,25 @@ export { isSecretKeyName } from "./key-patterns.js";
 /**
  * Creates all secret recognizers
  */
-export function createSecretRecognizers(): Recognizer[] {
+export function createSecretRecognizers(options?: {
+  secretKeyPatterns?: RegExp[];
+  minValueLength?: number;
+}): Recognizer[] {
+  const hasCustomOptions =
+    (options?.secretKeyPatterns !== undefined && options.secretKeyPatterns.length > 0) ||
+    options?.minValueLength !== undefined;
+
   return [
     apiKeyRecognizer,
     privateKeyRecognizer,
     jwtRecognizer,
     connectionStringRecognizer,
     awsCredentialsRecognizer,
-    envVarSecretRecognizer,
-    configSecretRecognizer,
+    hasCustomOptions
+      ? createEnvVarSecretRecognizer(options?.minValueLength, options?.secretKeyPatterns)
+      : envVarSecretRecognizer,
+    hasCustomOptions
+      ? createConfigSecretRecognizer(options?.minValueLength, options?.secretKeyPatterns)
+      : configSecretRecognizer,
   ];
 }

--- a/test/recognizers/secrets/index.test.ts
+++ b/test/recognizers/secrets/index.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { createSecretRecognizers } from "../../../src/recognizers/secrets/index.js";
+import { PIIType } from "../../../src/types/index.js";
+
+describe("createSecretRecognizers", () => {
+  it("should return all recognizers with defaults", () => {
+    const recognizers = createSecretRecognizers();
+    expect(recognizers.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it("should pass minValueLength to env-var and config-secret recognizers", () => {
+    // With default minValueLength (8), this short value IS detected
+    const defaultRecognizers = createSecretRecognizers();
+    const envVarDefault = defaultRecognizers.find(
+      (r) => r.type === PIIType.ENV_VAR_SECRET,
+    )!;
+    const shortEnvText = "API_KEY=short123";
+    expect(envVarDefault.find(shortEnvText)).toHaveLength(1);
+
+    // With minValueLength=20, same short value is NOT detected
+    const customRecognizers = createSecretRecognizers({ minValueLength: 20 });
+    const envVarCustom = customRecognizers.find(
+      (r) => r.type === PIIType.ENV_VAR_SECRET,
+    )!;
+    expect(envVarCustom.find(shortEnvText)).toHaveLength(0);
+
+    const configSecretCustom = customRecognizers.find(
+      (r) => r.type === PIIType.CONFIG_SECRET,
+    )!;
+    const shortConfigText = '"api_key": "short123"';
+    expect(configSecretCustom.find(shortConfigText)).toHaveLength(0);
+  });
+
+  it("should pass secretKeyPatterns to env-var and config-secret recognizers", () => {
+    const customRecognizers = createSecretRecognizers({
+      secretKeyPatterns: [/^MY_APP_/i],
+    });
+
+    const envVar = customRecognizers.find(
+      (r) => r.type === PIIType.ENV_VAR_SECRET,
+    )!;
+    // MY_APP_SETTING is not a default secret key name, but matches our custom pattern
+    const envText = "MY_APP_SETTING=some-long-secret-value-here";
+    expect(envVar.find(envText)).toHaveLength(1);
+
+    const configSecret = customRecognizers.find(
+      (r) => r.type === PIIType.CONFIG_SECRET,
+    )!;
+    const configText = '"my_app_setting": "some-long-secret-value-here"';
+    expect(configSecret.find(configText)).toHaveLength(1);
+  });
+
+  it("should not match custom key patterns without the option", () => {
+    const defaultRecognizers = createSecretRecognizers();
+
+    const envVar = defaultRecognizers.find(
+      (r) => r.type === PIIType.ENV_VAR_SECRET,
+    )!;
+    const envText = "MY_APP_SETTING=some-long-secret-value-here";
+    expect(envVar.find(envText)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Pass `secretKeyPatterns` and `minValueLength` from `SecretsConfig` through `createSecretRecognizers()` to `createEnvVarSecretRecognizer()` and `createConfigSecretRecognizer()`
- Previously these config options were defined in the type but never wired to the recognizers that use them — users could set them but they had no effect

The factory functions already accepted these parameters; they just weren't being called with them.

Closes #37

## Test plan

- [x] 4 new tests verifying `createSecretRecognizers` forwards `minValueLength` and `secretKeyPatterns` to both env-var and config-secret recognizers
- [x] All 87 secret recognizer tests pass
- [x] TypeScript type check passes
- [x] Lint passes