### PR TITLE
fix: guard PUBLISH_FLAGS expansion against unbound variable on empty array

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -66,7 +66,7 @@ npx vitest run
 # Publish SDK
 echo "==> Publishing rehydra@$SDK_VERSION..."
 cd "$ROOT"
-npm publish "${PUBLISH_FLAGS[@]}"
+npm publish ${PUBLISH_FLAGS[@]+"${PUBLISH_FLAGS[@]}"}
 
 # Sync CLI dependency version to the just-published SDK version
 echo "==> Syncing @rehydra/cli dependency to rehydra@^$SDK_VERSION..."
@@ -80,7 +80,7 @@ fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 
 # Publish CLI
 echo "==> Publishing @rehydra/cli@$CLI_VERSION..."
-npm publish --access public "${PUBLISH_FLAGS[@]}"
+npm publish --access public ${PUBLISH_FLAGS[@]+"${PUBLISH_FLAGS[@]}"}
 
 # Sync plugin dependency version to the just-published SDK version
 echo "==> Syncing @rehydra/opencode dependency to rehydra@^$SDK_VERSION..."
@@ -94,7 +94,7 @@ fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
 
 # Publish plugin
 echo "==> Publishing @rehydra/opencode@$PLUGIN_VERSION..."
-npm publish --access public "${PUBLISH_FLAGS[@]}"
+npm publish --access public ${PUBLISH_FLAGS[@]+"${PUBLISH_FLAGS[@]}"}
 
 echo ""
 echo "==> Done! Published:"


### PR DESCRIPTION
## Summary

Fixes an `unbound variable` error in `scripts/publish.sh` that occurs when `PUBLISH_FLAGS` is an empty array under bash strict mode (`set -u`).

The old form `"${PUBLISH_FLAGS[@]}"` throws `unbound variable` on an empty array in some bash versions. The new `${PUBLISH_FLAGS[@]+"${PUBLISH_FLAGS[@]}"}` form only expands the array if it is set, safely producing nothing when empty.

The same fix is applied to all three publish commands (SDK, CLI, and plugin).

## Test plan

- Verified the script no longer errors when `PUBLISH_FLAGS` is empty (the common, non-dry-run case).
- Verified flags are still passed through when `PUBLISH_FLAGS` is populated.