### PR TITLE
feat(proxy): log per-request anonymization with --verbose

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -18,7 +18,7 @@ import {
   incomingMessageToRequest,
   writeResponse,
 } from "../../proxy/index.js";
-import type { RehydraProxyConfig } from "../../proxy/types.js";
+import type { RehydraProxyConfig, AnonymizeInfo } from "../../proxy/types.js";
 import type { ParsedOptions } from "../main.js";
 import { CLIError } from "../utils/errors.js";
 import { bold, dim, cyan, green, yellow } from "../utils/color.js";
@@ -159,6 +159,14 @@ export async function proxyCommand(
     policy,
     locale: options.locale,
     apiKey: llmApiKey,
+    // With --verbose, log per-request anonymization to stderr (never raw PII)
+    ...(options.verbose && !options.quiet
+      ? {
+          onAnonymize: (info: AnonymizeInfo): void => {
+            process.stderr.write(formatAnonymizeLog(info));
+          },
+        }
+      : {}),
   };
 
   // Start with regex-only proxy (instant startup)
@@ -314,6 +322,31 @@ async function loadNerAndSwap(
 }
 
 // --- helpers ---
+
+/**
+ * Format a one-line stderr log for a single intercepted request, e.g.
+ *   POST /v1/chat/completions → anonymized 1 EMAIL, 1 PERSON
+ * Reports types and counts only — never the raw PII values.
+ */
+function formatAnonymizeLog(info: AnonymizeInfo): string {
+  let path: string;
+  try {
+    path = new URL(info.url).pathname;
+  } catch {
+    path = info.url;
+  }
+
+  const prefix = `  ${cyan(info.method)} ${path} ${dim("→")} `;
+
+  if (info.totalEntities === 0) {
+    return prefix + dim("no PII detected") + "\n";
+  }
+
+  const parts = Object.entries(info.countsByType)
+    .map(([type, count]) => `${count} ${type}`)
+    .join(", ");
+  return prefix + green(`anonymized ${parts}`) + "\n";
+}
 
 function validateNerMode(mode: string): NERConfig["mode"] {
   const valid = ["disabled", "quantized", "standard"];

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -87,6 +87,9 @@ ${bold("EXAMPLES")}
   rehydra proxy claude
   ${dim("# then: export ANTHROPIC_BASE_URL=http://127.0.0.1:8787")}
 
+  ${dim("# Start a proxy and log what PII is anonymized per request")}
+  rehydra proxy openai --verbose
+
 ${bold("EXIT CODES")}
   0  Success
   1  Error

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -20,5 +20,10 @@ export {
   AnthropicProvider,
   type LLMContentProvider,
 } from "./providers/index.js";
-export type { RehydraFetchConfig, RehydraProxyConfig, OnToolCallFn } from "./types.js";
+export type {
+  RehydraFetchConfig,
+  RehydraProxyConfig,
+  OnToolCallFn,
+  AnonymizeInfo,
+} from "./types.js";
 export { DEFAULT_PII_SYSTEM_INSTRUCTION } from "./system-instruction.js";

--- a/src/proxy/rehydra-fetch.ts
+++ b/src/proxy/rehydra-fetch.ts
@@ -163,6 +163,8 @@ export function createRehydraFetch(
       const texts = provider.extractRequestText(body);
       const anonymizedTexts: string[] = [];
       let piiDetected = false;
+      const countsByType: Record<string, number> = {};
+      let totalEntities = 0;
 
       for (let i = 0; i < texts.length; i++) {
         const result = await session.anonymize(
@@ -174,6 +176,22 @@ export function createRehydraFetch(
         if (result.anonymizedText !== texts[i]) {
           piiDetected = true;
         }
+        for (const [type, count] of Object.entries(result.stats.countsByType)) {
+          if (count > 0) {
+            countsByType[type] = (countsByType[type] ?? 0) + count;
+            totalEntities += count;
+          }
+        }
+      }
+
+      // Report what was anonymized (types and counts only — never raw PII)
+      if (config.onAnonymize !== undefined) {
+        config.onAnonymize({
+          method: request.method,
+          url: request.url,
+          countsByType,
+          totalEntities,
+        });
       }
 
       // Rebuild the request body with anonymized text

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -24,6 +24,23 @@ export type OnToolCallFn = (
 ) => unknown;
 
 /**
+ * Summary of what an intercepted request anonymized. Passed to the
+ * {@link RehydraFetchConfig.onAnonymize} hook for logging/observability.
+ *
+ * Contains only PII *types* and counts — never the raw PII values.
+ */
+export interface AnonymizeInfo {
+  /** HTTP method of the intercepted request (always "POST" in practice) */
+  method: string;
+  /** Upstream request URL */
+  url: string;
+  /** Detected entity count per PII type (only types with count > 0) */
+  countsByType: Record<string, number>;
+  /** Total entities detected across the whole request */
+  totalEntities: number;
+}
+
+/**
  * Configuration for the Rehydra fetch wrapper
  */
 export interface RehydraFetchConfig {
@@ -87,6 +104,14 @@ export interface RehydraFetchConfig {
    * @default 10
    */
   maxToolRounds?: number;
+
+  /**
+   * Hook invoked once per intercepted request, after anonymization and
+   * before forwarding upstream. Receives a summary of detected PII
+   * (types and counts only — never the raw values). Useful for verbose
+   * logging and observability.
+   */
+  onAnonymize?: (info: AnonymizeInfo) => void;
 }
 
 /**

--- a/test/cli/commands/proxy.test.ts
+++ b/test/cli/commands/proxy.test.ts
@@ -398,6 +398,64 @@ describe("proxy command", () => {
     });
   });
 
+  // --- Verbose logging ---
+
+  describe("verbose logging", () => {
+    it("should wire onAnonymize into config when --verbose is set", async () => {
+      const exitCode = await startAndShutdown("openai", makeOptions({ verbose: true, quiet: false }));
+      expect(exitCode).toBe(0);
+      const config = mockCreateRehydraProxy.mock.calls[0]![0];
+      expect(typeof config.onAnonymize).toBe("function");
+    });
+
+    it("should not set onAnonymize when --verbose is absent", async () => {
+      const exitCode = await startAndShutdown("openai", makeOptions({ verbose: false, quiet: false }));
+      expect(exitCode).toBe(0);
+      const config = mockCreateRehydraProxy.mock.calls[0]![0];
+      expect(config.onAnonymize).toBeUndefined();
+    });
+
+    it("should not set onAnonymize when quiet (even with --verbose)", async () => {
+      const exitCode = await startAndShutdown("openai", makeOptions({ verbose: true, quiet: true }));
+      expect(exitCode).toBe(0);
+      const config = mockCreateRehydraProxy.mock.calls[0]![0];
+      expect(config.onAnonymize).toBeUndefined();
+    });
+
+    it("should log detected PII types and counts to stderr", async () => {
+      const exitCode = await startAndShutdown("openai", makeOptions({ verbose: true, quiet: false }));
+      expect(exitCode).toBe(0);
+      const config = mockCreateRehydraProxy.mock.calls[0]![0];
+
+      config.onAnonymize!({
+        method: "POST",
+        url: "http://127.0.0.1:8787/v1/chat/completions",
+        countsByType: { EMAIL: 1, PERSON: 2 },
+        totalEntities: 3,
+      });
+
+      const output = stderrChunks.join("");
+      expect(output).toContain("POST");
+      expect(output).toContain("/v1/chat/completions");
+      expect(output).toContain("anonymized 1 EMAIL, 2 PERSON");
+    });
+
+    it("should log 'no PII detected' when nothing was anonymized", async () => {
+      const exitCode = await startAndShutdown("openai", makeOptions({ verbose: true, quiet: false }));
+      expect(exitCode).toBe(0);
+      const config = mockCreateRehydraProxy.mock.calls[0]![0];
+
+      config.onAnonymize!({
+        method: "POST",
+        url: "http://127.0.0.1:8787/v1/chat/completions",
+        countsByType: {},
+        totalEntities: 0,
+      });
+
+      expect(stderrChunks.join("")).toContain("no PII detected");
+    });
+  });
+
   // --- NER background loading ---
 
   describe("NER background loading", () => {

--- a/test/proxy/rehydra-fetch.test.ts
+++ b/test/proxy/rehydra-fetch.test.ts
@@ -235,6 +235,86 @@ describe("createRehydraFetch", () => {
     expect(exists).toBe(true);
   });
 
+  describe("onAnonymize hook", () => {
+    it("reports detected PII types and counts (never raw values)", async () => {
+      mockServer = await createMockLLMServer();
+      const { port } = mockServer;
+
+      const calls: any[] = [];
+      const rehydraFetch = createRehydraFetch({
+        keyProvider: new InMemoryKeyProvider(),
+        piiStorageProvider: new InMemoryPIIStorageProvider(),
+        provider: "openai",
+        getSessionId: async () => "hook-test",
+        onAnonymize: (info) => calls.push(info),
+      });
+
+      await rehydraFetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "test",
+          messages: [
+            { role: "user", content: "Email john@example.com and jane@example.com" },
+          ],
+        }),
+      });
+
+      expect(calls).toHaveLength(1);
+      const info = calls[0];
+      expect(info.method).toBe("POST");
+      expect(info.url).toContain("/v1/chat/completions");
+      expect(info.countsByType.EMAIL).toBe(2);
+      expect(info.totalEntities).toBe(2);
+      // The hook must never receive the raw PII values
+      expect(JSON.stringify(info)).not.toContain("john@example.com");
+    });
+
+    it("fires with zero counts when no PII is present", async () => {
+      mockServer = await createMockLLMServer();
+      const { port } = mockServer;
+
+      const calls: any[] = [];
+      const rehydraFetch = createRehydraFetch({
+        keyProvider: new InMemoryKeyProvider(),
+        piiStorageProvider: new InMemoryPIIStorageProvider(),
+        provider: "openai",
+        getSessionId: async () => "hook-empty-test",
+        onAnonymize: (info) => calls.push(info),
+      });
+
+      await rehydraFetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "test",
+          messages: [{ role: "user", content: "Hello world" }],
+        }),
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].totalEntities).toBe(0);
+      expect(calls[0].countsByType).toEqual({});
+    });
+
+    it("does not fire for non-POST requests", async () => {
+      mockServer = await createMockLLMServer();
+      const { port } = mockServer;
+
+      const calls: any[] = [];
+      const rehydraFetch = createRehydraFetch({
+        keyProvider: new InMemoryKeyProvider(),
+        piiStorageProvider: new InMemoryPIIStorageProvider(),
+        provider: "openai",
+        onAnonymize: (info) => calls.push(info),
+      });
+
+      await rehydraFetch(`http://127.0.0.1:${port}/health`, { method: "GET" });
+
+      expect(calls).toHaveLength(0);
+    });
+  });
+
   describe("error handling", () => {
     it("should return 400 for malformed request body", async () => {
       const rehydraFetch = createRehydraFetch({


### PR DESCRIPTION
Closes #76.

## Problem

`--verbose` was documented ("Show detection details") but **not wired into the proxy command**, so a user running `rehydra proxy` had no way to observe that anonymization was happening. This was the root cause of #74, where a user saw their PII restored in the response (correct rehydration) and concluded — incorrectly — that nothing was being anonymized.

## Change

- Add an `onAnonymize` hook to `RehydraFetchConfig` (`src/proxy/types.ts`). It fires once per intercepted request, after anonymization and before forwarding upstream, with a new `AnonymizeInfo` summary: `{ method, url, countsByType, totalEntities }`. It carries **types and counts only — never raw PII values**.
- Aggregate detection counts in the anonymize loop in `src/proxy/rehydra-fetch.ts` and invoke the hook.
- Wire the CLI proxy command (`src/cli/commands/proxy.ts`) to log a one-line stderr summary when `--verbose` is set (and not `--quiet`):

  ```
  POST /v1/chat/completions → anonymized 1 EMAIL, 2 PERSON
  POST /v1/chat/completions → no PII detected
  ```

- Export `AnonymizeInfo` from `rehydra/proxy` and add a discoverable example to the CLI help.

## Tests

- `test/proxy/rehydra-fetch.test.ts`: hook reports correct types/counts, never leaks raw values, fires with zero counts when clean, and does not fire for non-POST requests.
- `test/cli/commands/proxy.test.ts`: `--verbose` wires the hook in (and is suppressed under `--quiet`/when absent); log output format for both the detected and "no PII detected" cases.
- Full suite green (1437 tests); also verified end-to-end through the real `createRehydraProxyServer` streaming-body path — the hook fires once with `{EMAIL:1, PHONE:1}`.

## Notes

The `onAnonymize` hook is part of the public `rehydra/proxy` API, so it's also usable by anyone embedding `createRehydraFetch`/`createRehydraProxy` for their own logging/metrics.