### PR TITLE
chore: document browser extension in README and ignore outreach dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ rehydra-sidecar/
 # Claude Code
 CLAUDE.md
 .claude/
+
+# Outreach materials (not part of the SDK)
+outreach/

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Names, emails, phone numbers, and secrets are replaced with placeholders in tran
 
 > **Note:** The proxy requires an [Anthropic API key](https://console.anthropic.com/settings/keys). Claude Max/Pro subscriptions use OAuth which `api.anthropic.com` does not support through proxies.
 
+### Browser extension — anonymize ChatGPT and Gemini
+
+Install the [Rehydra Chrome extension](https://chromewebstore.google.com/detail/rehydra-%E2%80%93-ki-privacy-date/oaiimlliicjbmgmamiahhnafpcenpohh) to protect PII directly in your browser. It replaces names, emails, phone numbers, and secrets with placeholders before your messages reach ChatGPT or Gemini, and rehydrates the responses back to real values in the UI. Detection runs on-device — no data leaves your machine.
+
 ### OpenCode plugin
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a **Browser extension** section to the README under Quick Start, linking to the [Rehydra Chrome Web Store listing](https://chromewebstore.google.com/detail/rehydra-%E2%80%93-ki-privacy-date/oaiimlliicjbmgmamiahhnafpcenpohh). The extension anonymizes ChatGPT and Gemini in the browser.
- Ignore the local `outreach/` directory (marketing materials, not part of the SDK).

## Notes
- `chore:` prefix — no release-please version bump.