### PR TITLE
fix: process long inputs in overlapping NER windows instead of truncating

### DIFF
--- a/src/ner/bio-decoder.ts
+++ b/src/ner/bio-decoder.ts
@@ -272,11 +272,13 @@ export function mergeAdjacentSpans(
     const isOnlyWhitespace = /^\s*$/.test(gapText);
 
     if (next.type === current.type && gap <= maxGap && isOnlyWhitespace) {
-      // Merge spans
+      // Merge spans; max() so a span contained in the current one
+      // (possible with overlapping inputs) can never shrink the result
+      const mergedEnd = Math.max(current.end, next.end);
       current = {
         ...current,
-        end: next.end,
-        text: originalText.slice(current.start, next.end),
+        end: mergedEnd,
+        text: originalText.slice(current.start, mergedEnd),
         confidence: (current.confidence + next.confidence) / 2,
       };
     } else {

--- a/src/ner/ner-model.ts
+++ b/src/ner/ner-model.ts
@@ -171,7 +171,8 @@ export class NERModel {
   }
 
   /**
-   * Runs a single NER pass: tokenize, infer, decode BIO tags.
+   * Runs a full NER pass: tokenize into overlapping windows, infer per
+   * window, decode BIO tags, and reconcile window results.
    * @param inputText - Text to tokenize and feed to the model
    * @param originalText - Original text used for extracting entity text (may differ in casing)
    */
@@ -180,23 +181,36 @@ export class NERModel {
     originalText: string,
     minConfidence: number
   ): Promise<SpanMatch[]> {
-    // Tokenize the input text (may be case-modified)
-    const tokenization = this.tokenizer!.tokenize(inputText);
+    // Tokenize into overlapping model-sized windows so inputs longer than
+    // maxLength tokens are fully processed instead of silently truncated
+    const windows = this.tokenizer!.tokenizeWindows(inputText);
 
-    // Run inference
-    const { labels, confidences } = await this.runInference(tokenization);
+    const spans: SpanMatch[] = [];
+    for (const window of windows) {
+      // Run inference
+      const { labels, confidences } = await this.runInference(window);
 
-    // Decode BIO tags using original text for entity text extraction
-    // (offsets are identical since casing doesn't change string length)
-    const rawEntities = decodeBIOTags(
-      tokenization.tokens,
-      labels,
-      confidences,
-      originalText
-    );
+      // Decode BIO tags using original text for entity text extraction
+      // (offsets are identical since casing doesn't change string length)
+      const rawEntities = decodeBIOTags(
+        window.tokens,
+        labels,
+        confidences,
+        originalText
+      );
 
-    // Convert to SpanMatch format with confidence filtering
-    return convertToSpanMatches(rawEntities, minConfidence);
+      // Keep only entities anchored in this window's core range; the
+      // overlap margins are context for the model, and entities starting
+      // there belong to a neighboring window
+      const anchored = rawEntities.filter(
+        (e) => e.start >= window.coreCharStart && e.start < window.coreCharEnd
+      );
+
+      // Convert to SpanMatch format with confidence filtering
+      spans.push(...convertToSpanMatches(anchored, minConfidence));
+    }
+
+    return spans;
   }
 
   /**

--- a/src/ner/ner-model.ts
+++ b/src/ner/ner-model.ts
@@ -199,18 +199,23 @@ export class NERModel {
         originalText
       );
 
-      // Keep only entities anchored in this window's core range; the
-      // overlap margins are context for the model, and entities starting
-      // there belong to a neighboring window
+      // Keep entities that overlap this window's core range. Overlap
+      // (rather than strict start-anchoring) tolerates adjacent windows
+      // decoding slightly different boundaries for the same entity near a
+      // core boundary — otherwise both windows could reject it and the
+      // entity would be dropped entirely
       const anchored = rawEntities.filter(
-        (e) => e.start >= window.coreCharStart && e.start < window.coreCharEnd
+        (e) => e.end > window.coreCharStart && e.start < window.coreCharEnd
       );
 
       // Convert to SpanMatch format with confidence filtering
       spans.push(...convertToSpanMatches(anchored, minConfidence));
     }
 
-    return spans;
+    // An entity straddling a core boundary can be kept by both adjacent
+    // windows; union overlapping same-type spans so it is reported once
+    // with its full detected extent
+    return mergeOverlappingWindowSpans(spans, originalText);
   }
 
   /**
@@ -426,6 +431,39 @@ export class NERModel {
     this.isLoaded = false;
     return Promise.resolve();
   }
+}
+
+/**
+ * Merges overlapping same-type spans collected from adjacent windows into
+ * their union. Windows can disagree on the exact boundaries of an entity
+ * near a core boundary; keeping the union guarantees no part of a detected
+ * entity is left unmasked.
+ */
+function mergeOverlappingWindowSpans(
+  spans: SpanMatch[],
+  originalText: string
+): SpanMatch[] {
+  if (spans.length <= 1) return spans;
+
+  const sorted = [...spans].sort((a, b) => a.start - b.start || b.end - a.end);
+  const merged: SpanMatch[] = [{ ...sorted[0]! }];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const span = sorted[i]!;
+    const last = merged[merged.length - 1]!;
+
+    if (span.type === last.type && span.start < last.end) {
+      if (span.end > last.end) {
+        last.end = span.end;
+        last.text = originalText.slice(last.start, last.end);
+      }
+      last.confidence = Math.max(last.confidence, span.confidence);
+    } else {
+      merged.push({ ...span });
+    }
+  }
+
+  return merged;
 }
 
 /**

--- a/src/ner/tokenizer.ts
+++ b/src/ner/tokenizer.ts
@@ -210,7 +210,7 @@ export class WordPieceTokenizer {
     const content = this.tokenizeContent(text);
 
     // Truncate if necessary (maxLength includes CLS and SEP)
-    const maxContent = this.config.maxLength - 2;
+    const maxContent = Math.max(0, this.config.maxLength - 2);
     const truncated =
       content.length > maxContent ? content.slice(0, maxContent) : content;
 
@@ -229,7 +229,9 @@ export class WordPieceTokenizer {
     overlap: number = DEFAULT_WINDOW_OVERLAP
   ): TokenizationWindow[] {
     const content = this.tokenizeContent(text);
-    const windowSize = this.config.maxLength - 2;
+    // Clamp to >= 1 so a degenerate maxLength (< 3) cannot produce a
+    // zero-token window and a non-advancing stride below
+    const windowSize = Math.max(1, this.config.maxLength - 2);
 
     // Short input: single window, identical to tokenize()
     if (content.length <= windowSize) {

--- a/src/ner/tokenizer.ts
+++ b/src/ner/tokenizer.ts
@@ -39,6 +39,28 @@ export interface TokenizationResult {
 }
 
 /**
+ * A model-sized window over the full token stream of a long input.
+ * Consecutive windows overlap so entities near a window boundary are seen
+ * with full context by at least one window. The core range delimits the
+ * characters this window is authoritative for: cores tile the input exactly,
+ * so an entity anchored (by start offset) in a core belongs to exactly one
+ * window and cross-window duplicates cannot occur.
+ */
+export interface TokenizationWindow extends TokenizationResult {
+  /** Start character offset (inclusive) of this window's core range */
+  coreCharStart: number;
+  /** End character offset (exclusive) of this window's core range */
+  coreCharEnd: number;
+}
+
+/**
+ * Default token overlap between consecutive windows.
+ * Entities up to half this length are guaranteed to fit entirely inside
+ * the window that owns them.
+ */
+export const DEFAULT_WINDOW_OVERLAP = 128;
+
+/**
  * HuggingFace tokenizer.json structure
  */
 interface HFTokenizerConfig {
@@ -180,22 +202,98 @@ export class WordPieceTokenizer {
   }
 
   /**
-   * Tokenizes text into tokens with offset tracking
+   * Tokenizes text into tokens with offset tracking.
+   * Truncates to maxLength tokens — use tokenizeWindows() for inputs that
+   * may exceed the model's sequence length.
    */
   tokenize(text: string): TokenizationResult {
-    const tokens: Token[] = [];
-    const tokenToCharSpan: Array<[number, number] | null> = [];
+    const content = this.tokenizeContent(text);
 
-    // Add CLS token
-    tokens.push({
-      id: this.clsId,
-      token: this.clsToken,
-      start: 0,
-      end: 0,
-      isContinuation: false,
-      isSpecial: true,
-    });
-    tokenToCharSpan.push(null);
+    // Truncate if necessary (maxLength includes CLS and SEP)
+    const maxContent = this.config.maxLength - 2;
+    const truncated =
+      content.length > maxContent ? content.slice(0, maxContent) : content;
+
+    return this.buildResult(truncated, text);
+  }
+
+  /**
+   * Tokenizes text into overlapping model-sized windows covering the full
+   * input, so no tokens are silently dropped for long texts.
+   * Each window carries a core character range; together the cores tile the
+   * input exactly. Callers should keep an entity only from the window whose
+   * core contains the entity's start offset.
+   */
+  tokenizeWindows(
+    text: string,
+    overlap: number = DEFAULT_WINDOW_OVERLAP
+  ): TokenizationWindow[] {
+    const content = this.tokenizeContent(text);
+    const windowSize = this.config.maxLength - 2;
+
+    // Short input: single window, identical to tokenize()
+    if (content.length <= windowSize) {
+      return [
+        {
+          ...this.buildResult(content, text),
+          coreCharStart: 0,
+          coreCharEnd: text.length,
+        },
+      ];
+    }
+
+    // Clamp overlap so the stride stays positive
+    const effectiveOverlap = Math.min(
+      Math.max(overlap, 0),
+      Math.floor(windowSize / 2)
+    );
+    const stride = windowSize - effectiveOverlap;
+
+    // Window start indices; the last window is right-aligned so it always
+    // ends exactly at the end of the token stream
+    const starts: number[] = [];
+    for (let s = 0; ; s += stride) {
+      if (s + windowSize >= content.length) {
+        starts.push(content.length - windowSize);
+        break;
+      }
+      starts.push(s);
+    }
+
+    const windows: TokenizationWindow[] = [];
+    for (let i = 0; i < starts.length; i++) {
+      const start = starts[i]!;
+      const end = start + windowSize;
+
+      // Core boundaries sit at the midpoint of each overlap region, so
+      // consecutive cores meet exactly and every token start is owned by
+      // precisely one window
+      const coreTokenStart =
+        i === 0 ? 0 : Math.floor((start + starts[i - 1]! + windowSize) / 2);
+      const coreTokenEnd =
+        i === starts.length - 1
+          ? content.length
+          : Math.floor((starts[i + 1]! + end) / 2);
+
+      windows.push({
+        ...this.buildResult(content.slice(start, end), text),
+        coreCharStart: i === 0 ? 0 : content[coreTokenStart]!.start,
+        coreCharEnd:
+          coreTokenEnd >= content.length
+            ? text.length
+            : content[coreTokenEnd]!.start,
+      });
+    }
+
+    return windows;
+  }
+
+  /**
+   * Tokenizes text into content tokens (no special tokens, no truncation)
+   * using greedy longest-match with character offset tracking
+   */
+  private tokenizeContent(text: string): Token[] {
+    const tokens: Token[] = [];
 
     // Preprocess text
     const processedText = this.config.doLowerCase ? text.toLowerCase() : text;
@@ -211,9 +309,9 @@ export class WordPieceTokenizer {
 
       // Find the longest matching token starting at this position
       const { token, id, length } = this.findBestToken(processedText, pos);
-      
+
       const isFirstOfWord = pos === 0 || /\s/.test(processedText[pos - 1]!);
-      
+
       tokens.push({
         id,
         token,
@@ -222,48 +320,48 @@ export class WordPieceTokenizer {
         isContinuation: !isFirstOfWord && !token.startsWith('▁'),
         isSpecial: false,
       });
-      tokenToCharSpan.push([pos, pos + length]);
-      
+
       pos += length;
     }
 
-    // Add SEP token
-    tokens.push({
-      id: this.sepId,
-      token: this.sepToken,
-      start: text.length,
-      end: text.length,
-      isContinuation: false,
-      isSpecial: true,
-    });
-    tokenToCharSpan.push(null);
+    return tokens;
+  }
 
-    // Truncate if necessary
-    const maxTokens = this.config.maxLength;
-    if (tokens.length > maxTokens) {
-      tokens.length = maxTokens - 1;
-      tokenToCharSpan.length = maxTokens - 1;
-      tokens.push({
+  /**
+   * Wraps content tokens with CLS/SEP and builds the model input arrays
+   */
+  private buildResult(contentTokens: Token[], text: string): TokenizationResult {
+    const tokens: Token[] = [
+      {
+        id: this.clsId,
+        token: this.clsToken,
+        start: 0,
+        end: 0,
+        isContinuation: false,
+        isSpecial: true,
+      },
+      ...contentTokens,
+      {
         id: this.sepId,
         token: this.sepToken,
         start: text.length,
         end: text.length,
         isContinuation: false,
         isSpecial: true,
-      });
-      tokenToCharSpan.push(null);
-    }
+      },
+    ];
 
-    // Build arrays
-    const inputIds = tokens.map((t) => t.id);
-    const attentionMask = tokens.map(() => 1);
-    const tokenTypeIds = tokens.map(() => 0);
+    const tokenToCharSpan: Array<[number, number] | null> = [
+      null,
+      ...contentTokens.map((t): [number, number] => [t.start, t.end]),
+      null,
+    ];
 
     return {
       tokens,
-      inputIds,
-      attentionMask,
-      tokenTypeIds,
+      inputIds: tokens.map((t) => t.id),
+      attentionMask: tokens.map(() => 1),
+      tokenTypeIds: tokens.map(() => 0),
       tokenToCharSpan,
     };
   }

--- a/test/ner/bio-decoder.test.ts
+++ b/test/ner/bio-decoder.test.ts
@@ -431,6 +431,21 @@ describe('BIO Decoder', () => {
       expect(merged[0]!.confidence).toBe(0.875); // Average
     });
 
+    it('should not shrink a span when merging a contained same-type span', () => {
+      const text = 'John Smith Meyer here';
+      const spans: SpanMatch[] = [
+        { type: PIIType.PERSON, start: 0, end: 16, confidence: 0.9, source: DetectionSource.NER, text: 'John Smith Meyer' },
+        { type: PIIType.PERSON, start: 5, end: 10, confidence: 0.8, source: DetectionSource.NER, text: 'Smith' },
+      ];
+
+      const merged = mergeAdjacentSpans(spans, text);
+
+      expect(merged).toHaveLength(1);
+      expect(merged[0]!.start).toBe(0);
+      expect(merged[0]!.end).toBe(16);
+      expect(merged[0]!.text).toBe('John Smith Meyer');
+    });
+
     it('should not merge spans of different types', () => {
       const text = 'John Berlin';
       const spans: SpanMatch[] = [

--- a/test/ner/ner-model.test.ts
+++ b/test/ner/ner-model.test.ts
@@ -145,6 +145,43 @@ describe('NER Model', () => {
         expect(types.has(PIIType.PERSON)).toBe(true);
       });
 
+      it('should detect entities beyond the 512-token window (issue #82)', async () => {
+        if (isCI || !modelAvailable) return;
+        // Filler pushes "John Smith" far past the model's single-window
+        // token limit; before windowing this leaked undetected
+        const text =
+          'This is neutral filler text. '.repeat(300) +
+          'Meeting with John Smith tomorrow.';
+        const nameOffset = text.indexOf('John Smith');
+
+        const result = await model!.predict(text);
+
+        const personSpans = result.spans.filter(s => s.type === PIIType.PERSON);
+        const johnSmith = personSpans.find(
+          s => s.start >= nameOffset && s.end <= nameOffset + 'John Smith'.length
+        );
+        expect(johnSmith).toBeDefined();
+        expect(johnSmith!.text).toContain('John');
+      }, 120000);
+
+      it('should detect entities in the middle of a long input', async () => {
+        if (isCI || !modelAvailable) return;
+        const filler = 'This is neutral filler text. ';
+        const text =
+          filler.repeat(150) +
+          'Please contact Maria Gonzalez in Barcelona. ' +
+          filler.repeat(150);
+        const nameOffset = text.indexOf('Maria Gonzalez');
+
+        const result = await model!.predict(text);
+
+        const personSpans = result.spans.filter(s => s.type === PIIType.PERSON);
+        const maria = personSpans.find(
+          s => s.start >= nameOffset && s.start < nameOffset + 'Maria'.length
+        );
+        expect(maria).toBeDefined();
+      }, 120000);
+
       it('should handle text without entities', async () => {
         if (isCI || !modelAvailable) return;
         const result = await model!.predict('The weather is nice today.');

--- a/test/ner/ner-model.test.ts
+++ b/test/ner/ner-model.test.ts
@@ -14,6 +14,7 @@ import {
   ensureModel,
   MODEL_REGISTRY,
 } from '../../src/ner/model-manager.js';
+import { WordPieceTokenizer } from '../../src/ner/tokenizer.js';
 import { createDefaultPolicy, PIIType } from '../../src/index.js';
 
 describe('NER Model', () => {
@@ -391,6 +392,113 @@ describe('NER Model', () => {
       const result = await isModelDownloaded('quantized');
       expect(typeof result).toBe('boolean');
     });
+  });
+});
+
+describe('windowed inference (stubbed session)', () => {
+  // Runs in CI: exercises the real predict() path — window loop, core
+  // anchoring, cross-window reconciliation — with a fake ONNX session that
+  // deterministically tags 'john' as B-PER and 'smith' as I-PER
+  const labelMap = ['O', 'B-PER', 'I-PER'];
+  const vocab = new Map<string, number>([
+    ['[UNK]', 0],
+    ['[CLS]', 1],
+    ['[SEP]', 2],
+    ['[PAD]', 3],
+    ['▁filler', 4],
+    ['▁john', 5],
+    ['▁smith', 6],
+  ]);
+  const JOHN_ID = 5n;
+  const SMITH_ID = 6n;
+
+  class FakeTensor {
+    constructor(
+      public type: string,
+      public data: unknown,
+      public dims: number[]
+    ) {}
+  }
+
+  const fakeSession = {
+    inputNames: ['input_ids', 'attention_mask'] as readonly string[],
+    outputNames: ['logits'] as readonly string[],
+    run(
+      feeds: Record<string, FakeTensor>
+    ): Promise<Record<string, { data: Float32Array }>> {
+      const ids = feeds['input_ids']!.data as BigInt64Array;
+      const logits = new Float32Array(ids.length * labelMap.length);
+      for (let i = 0; i < ids.length; i++) {
+        const labelIdx = ids[i] === JOHN_ID ? 1 : ids[i] === SMITH_ID ? 2 : 0;
+        logits[i * labelMap.length + labelIdx] = 10;
+      }
+      return Promise.resolve({ logits: { data: logits } });
+    },
+  };
+
+  function createStubbedModel(maxLength: number): INERModel {
+    const model = createNERModel({
+      modelPath: 'stub',
+      vocabPath: 'stub',
+      labelMap,
+      maxLength,
+      modelVersion: 'stub',
+    });
+    const internals = model as unknown as Record<string, unknown>;
+    internals['ort'] = { Tensor: FakeTensor };
+    internals['session'] = fakeSession;
+    internals['tokenizer'] = new WordPieceTokenizer(vocab, { maxLength });
+    internals['isLoaded'] = true;
+    return model;
+  }
+
+  it('should emit a boundary-straddling entity exactly once at every position', async () => {
+    // maxLength 12 -> 10 content tokens per window; sweeping the name one
+    // token at a time crosses every window/core boundary alignment
+    const model = createStubbedModel(12);
+
+    for (let before = 0; before <= 30; before++) {
+      const text =
+        'filler '.repeat(before) + 'john smith ' + 'filler '.repeat(10);
+      const nameStart = text.indexOf('john');
+      const nameEnd = nameStart + 'john smith'.length;
+
+      const result = await model.predict(text);
+      const personSpans = result.spans.filter(
+        (s) => s.type === PIIType.PERSON
+      );
+
+      expect(personSpans.length, `position ${before}`).toBe(1);
+      expect(personSpans[0]!.start, `position ${before}`).toBe(nameStart);
+      expect(personSpans[0]!.end, `position ${before}`).toBe(nameEnd);
+      expect(personSpans[0]!.text, `position ${before}`).toBe('john smith');
+    }
+  });
+
+  it('should detect all entities in a multi-window input', async () => {
+    const model = createStubbedModel(12);
+    const text =
+      'john smith ' +
+      'filler '.repeat(15) +
+      'john smith ' +
+      'filler '.repeat(15) +
+      'john smith';
+
+    const result = await model.predict(text);
+    const personSpans = result.spans.filter((s) => s.type === PIIType.PERSON);
+
+    expect(personSpans.length).toBe(3);
+    for (const span of personSpans) {
+      expect(span.text).toBe('john smith');
+    }
+  });
+
+  it('should match single-window behavior for short inputs', async () => {
+    const model = createStubbedModel(512);
+    const result = await model.predict('filler john smith filler');
+
+    expect(result.spans.length).toBe(1);
+    expect(result.spans[0]!.text).toBe('john smith');
   });
 });
 

--- a/test/ner/tokenizer.test.ts
+++ b/test/ner/tokenizer.test.ts
@@ -212,6 +212,67 @@ describe("WordPieceTokenizer", () => {
       expect(covered).toEqual(reference);
     });
 
+    it("should terminate and cover all tokens for degenerate maxLength", () => {
+      // maxLength <= 2 leaves no room for content tokens; must not hang
+      const tokenizer = new WordPieceTokenizer(mockVocab, { maxLength: 2 });
+      const text = "hello world hello world";
+
+      const windows = tokenizer.tokenizeWindows(text);
+
+      const covered = windows.flatMap((w) =>
+        w.tokens.filter(
+          (t) =>
+            !t.isSpecial &&
+            t.start >= w.coreCharStart &&
+            t.start < w.coreCharEnd
+        )
+      );
+      expect(covered.length).toBe(4);
+    });
+
+    it("should cover continuation tokens exactly once when windows split mid-word", () => {
+      // 'abcd' tokenizes as ▁ab + cd, so window and core boundaries can
+      // fall inside a word — the normal case with a real subword vocab
+      const subwordVocab = new Map<string, number>([
+        ["[UNK]", 0],
+        ["[CLS]", 1],
+        ["[SEP]", 2],
+        ["[PAD]", 3],
+        ["▁ab", 4],
+        ["cd", 5],
+      ]);
+      const tokenizer = new WordPieceTokenizer(subwordVocab, {
+        maxLength: 13,
+      });
+      const text = "abcd ".repeat(40).trim(); // 80 tokens
+
+      const reference = new WordPieceTokenizer(subwordVocab, {
+        maxLength: 100000,
+      })
+        .tokenize(text)
+        .tokens.filter((t) => !t.isSpecial)
+        .map((t) => [t.start, t.end, t.isContinuation]);
+
+      const windows = tokenizer.tokenizeWindows(text, 4);
+      const covered = windows.flatMap((w) =>
+        w.tokens
+          .filter(
+            (t) =>
+              !t.isSpecial &&
+              t.start >= w.coreCharStart &&
+              t.start < w.coreCharEnd
+          )
+          .map((t) => [t.start, t.end, t.isContinuation])
+      );
+
+      expect(covered).toEqual(reference);
+
+      // The scenario must actually occur: some window starts mid-word
+      expect(
+        windows.some((w) => w.tokens[1]?.isContinuation === true)
+      ).toBe(true);
+    });
+
     it("should include tokens past the single-window truncation point", () => {
       const tokenizer = new WordPieceTokenizer(mockVocab, { maxLength: 12 });
       const text = "hello world ".repeat(20) + "john smith";

--- a/test/ner/tokenizer.test.ts
+++ b/test/ner/tokenizer.test.ts
@@ -122,6 +122,118 @@ describe("WordPieceTokenizer", () => {
     });
   });
 
+  describe("tokenizeWindows", () => {
+    const mockVocab = new Map<string, number>([
+      ["[UNK]", 0],
+      ["[CLS]", 1],
+      ["[SEP]", 2],
+      ["[PAD]", 3],
+      ["▁hello", 4],
+      ["▁world", 5],
+      ["▁john", 6],
+      ["▁smith", 7],
+    ]);
+
+    it("should return a single window identical to tokenize() for short text", () => {
+      const tokenizer = new WordPieceTokenizer(mockVocab);
+      const text = "hello world";
+
+      const windows = tokenizer.tokenizeWindows(text);
+
+      expect(windows.length).toBe(1);
+      expect(windows[0]!.inputIds).toEqual(tokenizer.tokenize(text).inputIds);
+      expect(windows[0]!.coreCharStart).toBe(0);
+      expect(windows[0]!.coreCharEnd).toBe(text.length);
+    });
+
+    it("should produce multiple overlapping windows for long text", () => {
+      // maxLength 12 -> 10 content tokens per window
+      const tokenizer = new WordPieceTokenizer(mockVocab, { maxLength: 12 });
+      const text = "hello world ".repeat(20).trim(); // 40 tokens
+
+      const windows = tokenizer.tokenizeWindows(text, 4);
+
+      expect(windows.length).toBeGreaterThan(1);
+
+      for (const window of windows) {
+        expect(window.tokens.length).toBeLessThanOrEqual(12);
+        expect(window.tokens[0]?.token).toBe("[CLS]");
+        expect(window.tokens[window.tokens.length - 1]?.token).toBe("[SEP]");
+      }
+
+      // Consecutive windows share tokens (overlap)
+      for (let i = 1; i < windows.length; i++) {
+        const prevContent = windows[i - 1]!.tokens.filter((t) => !t.isSpecial);
+        const currContent = windows[i]!.tokens.filter((t) => !t.isSpecial);
+        expect(currContent[0]!.start).toBeLessThan(
+          prevContent[prevContent.length - 1]!.end
+        );
+      }
+    });
+
+    it("should tile core ranges exactly over the full text", () => {
+      const tokenizer = new WordPieceTokenizer(mockVocab, { maxLength: 12 });
+      const text = "hello world ".repeat(20).trim();
+
+      const windows = tokenizer.tokenizeWindows(text, 4);
+
+      expect(windows[0]!.coreCharStart).toBe(0);
+      expect(windows[windows.length - 1]!.coreCharEnd).toBe(text.length);
+      for (let i = 1; i < windows.length; i++) {
+        expect(windows[i]!.coreCharStart).toBe(windows[i - 1]!.coreCharEnd);
+      }
+    });
+
+    it("should cover every token exactly once across window cores", () => {
+      const tokenizer = new WordPieceTokenizer(mockVocab, { maxLength: 12 });
+      const text = "hello world ".repeat(20) + "john smith";
+
+      // Reference: untruncated tokenization
+      const reference = new WordPieceTokenizer(mockVocab, {
+        maxLength: 100000,
+      })
+        .tokenize(text)
+        .tokens.filter((t) => !t.isSpecial)
+        .map((t) => [t.start, t.end]);
+
+      const covered = tokenizer
+        .tokenizeWindows(text, 4)
+        .flatMap((w) =>
+          w.tokens
+            .filter(
+              (t) =>
+                !t.isSpecial &&
+                t.start >= w.coreCharStart &&
+                t.start < w.coreCharEnd
+            )
+            .map((t) => [t.start, t.end])
+        );
+
+      expect(covered).toEqual(reference);
+    });
+
+    it("should include tokens past the single-window truncation point", () => {
+      const tokenizer = new WordPieceTokenizer(mockVocab, { maxLength: 12 });
+      const text = "hello world ".repeat(20) + "john smith";
+      const johnOffset = text.indexOf("john");
+
+      const truncated = tokenizer.tokenize(text);
+      const truncatedMax = Math.max(
+        ...truncated.tokens.filter((t) => !t.isSpecial).map((t) => t.end)
+      );
+      expect(truncatedMax).toBeLessThan(johnOffset);
+
+      const windows = tokenizer.tokenizeWindows(text, 4);
+      const owner = windows.find(
+        (w) => johnOffset >= w.coreCharStart && johnOffset < w.coreCharEnd
+      );
+      expect(owner).toBeDefined();
+      expect(
+        owner!.tokens.some((t) => !t.isSpecial && t.start === johnOffset)
+      ).toBe(true);
+    });
+  });
+
   describe("with real vocab (integration)", () => {
     let tokenizer: WordPieceTokenizer | null = null;
     let modelAvailable = false;


### PR DESCRIPTION
Fixes #82

## Problem

`WordPieceTokenizer.tokenize()` truncated the token stream at `maxLength` (default 512), and `NERModel.predict()` ran a single inference pass. Any NER-detectable PII (PERSON, ORG, LOCATION) past the truncation point stayed in plaintext while anonymization reported success. The leak-scan validator only covers regex-detectable types, so the failure was silent.

## Approach

As proposed in the issue: tokenize without truncation, divide the token stream into overlapping model-sized windows, run inference per window with global character offsets preserved, and reconcile before the existing cleanup and policy filtering.

- **`tokenizeWindows()`** (new): slices the full token stream into windows of `maxLength − 2` content tokens (room for CLS/SEP) with a default 128-token overlap; the last window is right-aligned so it always ends at the text end. Each window carries a **core character range** whose boundaries sit at the midpoint of each overlap region — cores tile the input exactly, so every character is owned by precisely one window.
- **`runNERPass()`**: runs inference per window and keeps only entities whose start offset falls inside that window's core. Overlap margins give the model full context at boundaries; cross-window duplicates are impossible by construction, so no dedup heuristics are needed.
- Short inputs produce a single window with byte-identical model input to the previous code. `tokenize()` keeps its truncating behavior for compatibility.

Downstream stages (case fallback, span cleanup, resolver, policy filtering) are untouched. The proxy and inference-server paths are fixed transitively since they call the same `predict()`.

## Verification

- 5 new tokenizer unit tests covering the window invariants: exact core tiling, every token covered exactly once, overlap presence, single-window equivalence for short inputs.
- 2 new real-model integration tests: entity past the 512-token limit (the issue's repro) and entity mid-way through a long input.
- The issue's exact reproduction script, run against the real quantized model through the full anonymizer path: before `leaked: true, entities: 0` → after the name at offset 8,713 is masked.
- A 32-position sweep placing a person name at 20-sentence steps across ~4 windows of text: detected at every position, including spots straddling each window boundary.
- Full suite passes with no regressions; lint and `tsc` clean.

## Notes

- Long inputs now cost one inference pass per window (stride 382 tokens at defaults); short inputs are unaffected.
- Entities longer than half the window overlap (64 tokens at defaults) near a window boundary could still be clipped — far beyond any realistic name/org/location span.