### PR TITLE
fix: fall back to registry label map instead of mismatched default

### DIFF
--- a/src/core/anonymizer.ts
+++ b/src/core/anonymizer.ts
@@ -31,13 +31,13 @@ import {
   NERModelStub,
   createNERModel,
   createInferenceServerNERModel,
-  DEFAULT_LABEL_MAP,
   type OrtSessionOptions,
 } from "../ner/index.js";
 
 import {
   type NERModelMode,
   ensureModel,
+  loadLabelMap,
   type DownloadProgressCallback,
 } from "../ner/model-manager.js";
 
@@ -454,15 +454,9 @@ export class Anonymizer {
         }
       );
 
-      // Load label map
-      let labelMap = DEFAULT_LABEL_MAP;
-      try {
-        const storage = await getStorageProvider();
-        const labelMapContent = await storage.readTextFile(labelMapPath);
-        labelMap = JSON.parse(labelMapContent) as string[];
-      } catch {
-        // Use default label map
-      }
+      // Load label map (falls back to the registry map for this mode, which
+      // matches the model head — never a generic default)
+      const labelMap = await loadLabelMap(this.nerConfig.mode, labelMapPath);
 
       this.nerModel = createNERModel({
         modelPath,

--- a/src/ner/model-manager.ts
+++ b/src/ner/model-manager.ts
@@ -404,6 +404,38 @@ export async function ensureModel(
 }
 
 /**
+ * Loads the label map for a registry model, preferring the label_map.json
+ * persisted by ensureModel and falling back to the registry's map for the
+ * mode. The registry is authoritative — it is the source ensureModel writes
+ * to the file — so a missing or corrupted file never changes the decoded
+ * label order (a mismatched map silently misclassifies every NER entity).
+ */
+export async function loadLabelMap(
+  mode: "standard" | "quantized",
+  labelMapPath: string
+): Promise<string[]> {
+  const registryLabelMap = MODEL_REGISTRY[mode].labelMap;
+
+  try {
+    const storage = await getStorage();
+    const content = await storage.readTextFile(labelMapPath);
+    const parsed: unknown = JSON.parse(content);
+
+    if (
+      Array.isArray(parsed) &&
+      parsed.length > 0 &&
+      parsed.every((label) => typeof label === "string")
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to registry map
+  }
+
+  return registryLabelMap;
+}
+
+/**
  * Clears cached models
  */
 export async function clearModelCache(

--- a/test/ner/model-manager.test.ts
+++ b/test/ner/model-manager.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Model Manager Tests
+ * Tests label map resolution for registry models
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadLabelMap, MODEL_REGISTRY } from '../../src/ner/model-manager.js';
+
+describe('loadLabelMap', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'rehydra-label-map-'));
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('should load the label map from label_map.json when present', async () => {
+    const customMap = ['O', 'B-PER', 'I-PER'];
+    const path = join(dir, 'valid.json');
+    await writeFile(path, JSON.stringify(customMap));
+
+    const labelMap = await loadLabelMap('quantized', path);
+
+    expect(labelMap).toEqual(customMap);
+  });
+
+  it('should fall back to the registry map when the file is missing', async () => {
+    const labelMap = await loadLabelMap(
+      'quantized',
+      join(dir, 'does-not-exist.json')
+    );
+
+    expect(labelMap).toEqual(MODEL_REGISTRY.quantized.labelMap);
+  });
+
+  it('should fall back to the registry map for corrupted JSON', async () => {
+    const path = join(dir, 'corrupt.json');
+    await writeFile(path, '{not json');
+
+    const labelMap = await loadLabelMap('standard', path);
+
+    expect(labelMap).toEqual(MODEL_REGISTRY.standard.labelMap);
+  });
+
+  it('should fall back to the registry map for wrong-shaped content', async () => {
+    for (const [name, content] of [
+      ['object.json', '{"0": "O"}'],
+      ['empty-array.json', '[]'],
+      ['mixed-array.json', '["O", 1, "B-PER"]'],
+    ] as const) {
+      const path = join(dir, name);
+      await writeFile(path, content);
+
+      const labelMap = await loadLabelMap('quantized', path);
+
+      expect(labelMap, name).toEqual(MODEL_REGISTRY.quantized.labelMap);
+    }
+  });
+
+  it('registry maps must match the model head order (DATE before PER)', () => {
+    // Both shipped models were trained with this exact head order; a
+    // mismatched map silently misclassifies every entity (see issue #85)
+    for (const mode of ['standard', 'quantized'] as const) {
+      expect(MODEL_REGISTRY[mode].labelMap.slice(0, 4)).toEqual([
+        'O',
+        'B-DATE',
+        'I-DATE',
+        'B-PER',
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #85

## Problem

If `label_map.json` is missing or unreadable in the model cache, the anonymizer silently fell back to `DEFAULT_LABEL_MAP`, whose label order (`[O, B-PER, …, B-MISC, I-MISC]`) is shifted by two positions relative to the shipped models' actual head order (`[O, B-DATE, I-DATE, B-PER, …, I-LOC]`). Every model output was decoded as the wrong label: PERSON as ORG, ORG as LOCATION, and LOCATION as MISC — dropped entirely and left unanonymized — while anonymization reported success. The leak-scan validator cannot catch it since it only covers regex-detectable types. Same silent-failure class as #82, discovered while verifying that fix.

## Change

- New `loadLabelMap(mode, labelMapPath)` in `model-manager.ts`: reads the persisted file, validates it is a non-empty string array, and otherwise falls back to `MODEL_REGISTRY[mode].labelMap` — the authoritative source `ensureModel` writes to that file in the first place, so the fallback is correct by construction. Corrupted files (bad JSON, wrong shape) now also fall back to the registry instead of being trusted or silently replaced by the stale default.
- The anonymizer uses it; `DEFAULT_LABEL_MAP` no longer participates in the registry-model path (it remains the default only for `custom` mode where no registry entry exists).

## Verification

- New unit tests for `loadLabelMap`: valid file wins, missing file / corrupted JSON / wrong-shaped content all fall back to the registry map, plus a guard test asserting the registry maps keep the DATE-before-PER head order the models were trained with.
- Reproduced the original failure scenario (model cache populated with all files except `label_map.json`): the previously-failing anonymizer-path NER tests (44 tests across `ner-model.test.ts` and `exclude-location-scopes.test.ts`) now pass with the file absent.
- Full suite: 1,455 passing; lint and `tsc` clean.