### PR TITLE
ci: fix publish job never running after a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     branches: [main]
+  # Manual escape hatch: publish the versions currently on main to npm (e.g.
+  # when a tagged release exists but the publish job did not run). npm rejects
+  # re-publishing an existing version, so a redundant dispatch fails loudly
+  # instead of double-publishing.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -10,10 +15,14 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs['.--release_created'] }}
-      tag_name: ${{ steps.release.outputs['.--tag_name'] }}
+      # The root package (path ".") gets un-prefixed outputs from
+      # release-please-action v4; path-prefixed names like ".--release_created"
+      # do not exist and silently resolve to empty.
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -22,7 +31,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The Release workflow's publish job has never run: release-please-action v4 emits **un-prefixed** outputs for the root path (`release_created`, `tag_name`) — the path-prefixed `.--release_created` form the workflow referenced doesn't exist, so it silently resolved to empty and the publish job was skipped on every release ([verified in the action source](https://github.com/googleapis/release-please-action/blob/v4/src/index.ts): `setPathOutput` only prefixes non-root paths). 0.11.1 was published by hand; v0.12.0 is currently tagged on GitHub but **not on npm**.

Changes:
- Reference the correct un-prefixed outputs so publish triggers on future releases.
- Add a `workflow_dispatch` trigger that runs only the publish job (release-please job is gated to `push`), as an escape hatch to publish an already-tagged release whose publish never ran — which is exactly what v0.12.0 needs. `!cancelled()` is required because a skipped `needs` job would otherwise skip publish regardless of its condition. npm refuses to overwrite an existing version, so a redundant dispatch fails loudly instead of double-publishing.

After merge I'll dispatch the workflow to get 0.12.0 onto npm.