### PR TITLE
feat(proxy): warn on duplicated path segment when upstream includes a base path

### DIFF
--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -40,6 +40,7 @@ const PROVIDER_CANONICAL: Record<string, "openai" | "anthropic"> = {
 function getConnectionHints(
   provider: "openai" | "anthropic",
   baseUrl: string,
+  upstream: URL,
   hasApiKey: boolean,
 ): string {
   const lines: string[] = [];
@@ -63,16 +64,20 @@ function getConnectionHints(
       `    ${dim(baseUrl)}`,
     );
   } else {
+    const upstreamPathSegments = upstream.pathname.split("/").filter(Boolean);
+    const openAIBaseUrl =
+      upstreamPathSegments.at(-1) === "v1" ? baseUrl : `${baseUrl}/v1`;
+
     lines.push(
       `  ${bold("Environment variable")}`,
-      `    export OPENAI_BASE_URL=${baseUrl}/v1`,
+      `    export OPENAI_BASE_URL=${openAIBaseUrl}`,
       "",
       `  ${bold("Cursor")}`,
       `    Settings ${dim("→")} Models ${dim("→")} OpenAI ${dim("→")} Override Base URL`,
-      `    ${dim(baseUrl + "/v1")}`,
+      `    ${dim(openAIBaseUrl)}`,
       "",
       `  ${bold("OpenAI SDK")}`,
-      `    ${dim(`new OpenAI({ baseURL: "${baseUrl}/v1" })`)}`,
+      `    ${dim(`new OpenAI({ baseURL: "${openAIBaseUrl}" })`)}`,
     );
   }
 
@@ -104,6 +109,7 @@ export async function proxyCommand(
   }
 
   const upstream = options.upstream ?? PROVIDER_UPSTREAMS[providerLower]!;
+  const parsedUpstream = validateUpstream(upstream);
   const port = parseInt(options.port ?? "8787", 10);
   const host = "127.0.0.1";
 
@@ -176,7 +182,7 @@ export async function proxyCommand(
 
             process.stderr.write(
               yellow(
-                `Warning: Upstream and incoming request path overlap on ${duplicated}; forwarding to ${upstream}${duplicated}/...\nTo fix, remove it from --upstream or the client base URL.\n`,
+                `Warning: Upstream and incoming request path overlap on ${duplicated}; forwarding to ${warning.upstreamBaseUrl}${duplicated}/...\nTo fix, remove it from --upstream or the client base URL.\n`,
               ),
             );
           },
@@ -234,7 +240,12 @@ export async function proxyCommand(
       "",
       `  ${bold("Configure your tools:")}`,
       "",
-      getConnectionHints(canonical, baseUrl, llmApiKey !== undefined),
+      getConnectionHints(
+        canonical,
+        baseUrl,
+        parsedUpstream,
+        llmApiKey !== undefined,
+      ),
       "",
       `  ${dim("Ctrl+C to stop")}`,
       "",
@@ -346,6 +357,33 @@ async function loadNerAndSwap(
 }
 
 // --- helpers ---
+
+function validateUpstream(value: string): URL {
+  const error = (): CLIError =>
+    new CLIError(
+      `Invalid --upstream "${value}": expected an absolute http:// or https:// URL`,
+    );
+
+  if (!/^https?:\/\//i.test(value)) {
+    throw error();
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw error();
+  }
+
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.hostname === ""
+  ) {
+    throw error();
+  }
+
+  return parsed;
+}
 
 /**
  * Format a one-line stderr log for a single intercepted request, e.g.

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -152,8 +152,9 @@ export async function proxyCommand(
   // LLM API key — from --api-key flag or LLM_API_KEY env var
   const llmApiKey = options["api-key"] ?? process.env["LLM_API_KEY"];
 
-  // Avoid warning on every request
-  let hasShownPathOverlapWarning = false;
+  // Overlaps already reported, so each distinct one is only warned about once.
+  // Bounded by the upstream path depth — the library always reports a suffix of it.
+  const shownPathOverlaps = new Set<string>();
 
   // Build shared proxy config (without NER initially)
   const baseProxyConfig: RehydraProxyConfig = {
@@ -173,12 +174,10 @@ export async function proxyCommand(
     ...(!options.quiet
       ? {
           onPathOverlapWarning: (warning): void => {
-            if (hasShownPathOverlapWarning) return;
-
-            // Prevent multiple warnings in same session
-            hasShownPathOverlapWarning = true;
-
             const duplicated = "/" + warning.overlappingSegments.join("/");
+
+            if (shownPathOverlaps.has(duplicated)) return;
+            shownPathOverlaps.add(duplicated);
 
             process.stderr.write(
               yellow(
@@ -375,11 +374,11 @@ function validateUpstream(value: string): URL {
     throw error();
   }
 
-  if (
-    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
-    parsed.hostname === ""
-  ) {
-    throw error();
+  // Reject upstream URL's with search params or hash fragments, since they won't create a valid base URL for the proxy forwarding
+  if (/[?#]/.test(parsed.href)) {
+    throw new CLIError(
+      `Invalid --upstream "${value}": must not include query parameters or hash fragment`,
+    );
   }
 
   return parsed;

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -146,6 +146,9 @@ export async function proxyCommand(
   // LLM API key — from --api-key flag or LLM_API_KEY env var
   const llmApiKey = options["api-key"] ?? process.env["LLM_API_KEY"];
 
+  // Avoid warning on every request
+  let hasShownPathOverlapWarning = false;
+
   // Build shared proxy config (without NER initially)
   const baseProxyConfig: RehydraProxyConfig = {
     upstream,
@@ -159,6 +162,27 @@ export async function proxyCommand(
     policy,
     locale: options.locale,
     apiKey: llmApiKey,
+
+    // Warn about overlapping paths without exposing request paths or queries
+    ...(!options.quiet
+      ? {
+          onPathOverlapWarning: (warning): void => {
+            if (hasShownPathOverlapWarning) return;
+
+            // Prevent multiple warnings in same session
+            hasShownPathOverlapWarning = true;
+
+            const duplicated = "/" + warning.overlappingSegments.join("/");
+
+            process.stderr.write(
+              yellow(
+                `Warning: Upstream and incoming request path overlap on ${duplicated}; forwarding to ${upstream}${duplicated}/...\nTo fix, remove it from --upstream or the client base URL.\n`,
+              ),
+            );
+          },
+        }
+      : {}),
+
     // With --verbose, log per-request anonymization to stderr (never raw PII)
     ...(options.verbose && !options.quiet
       ? {

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -374,7 +374,7 @@ function validateUpstream(value: string): URL {
     throw error();
   }
 
-  // Reject upstream URL's with search params or hash fragments, since they won't create a valid base URL for the proxy forwarding
+  // Reject upstream URLs with search params or hash fragments, since they won't create a valid base URL for the proxy forwarding
   if (/[?#]/.test(parsed.href)) {
     throw new CLIError(
       `Invalid --upstream "${value}": must not include query parameters or hash fragment`,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -56,7 +56,7 @@ ${bold("OPTIONS")}
       --secrets            Enable secrets/credentials detection
       --env-file <file>    .env file path for literal value redaction
   -p, --port <port>        Proxy port (default: 8787)
-      --upstream <url>     Custom upstream URL (overrides provider default)
+      --upstream <url>     Absolute HTTP(S) upstream URL (overrides provider default)
       --api-key <key>      LLM API key (or set LLM_API_KEY env var)
       --tag-open <str>     Tag open delimiter (default: "<")
       --tag-close <str>    Tag close delimiter (default: "/>")

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -25,5 +25,6 @@ export type {
   RehydraProxyConfig,
   OnToolCallFn,
   AnonymizeInfo,
+  PathOverlapWarning,
 } from "./types.js";
 export { DEFAULT_PII_SYSTEM_INSTRUCTION } from "./system-instruction.js";

--- a/src/proxy/rehydra-proxy.ts
+++ b/src/proxy/rehydra-proxy.ts
@@ -92,6 +92,7 @@ export function createRehydraProxy(
         shouldCheckPathOverlap = false;
 
         config.onPathOverlapWarning?.({
+          upstreamBaseUrl: upstream,
           overlappingSegments,
         });
       }

--- a/src/proxy/rehydra-proxy.ts
+++ b/src/proxy/rehydra-proxy.ts
@@ -61,8 +61,8 @@ export function createRehydraProxy(
   // Create the underlying Rehydra fetch wrapper
   const rehydraFetch = createRehydraFetch(config);
 
-  // Skip the per-request overlap check when there is no listener or upstream path segments, and stop checking after the first warning
-  let shouldCheckPathOverlap =
+  // Skip the per-request overlap check when there is no listener or upstream path segments
+  const shouldCheckPathOverlap =
     config.onPathOverlapWarning !== undefined && upstreamPathSegments.length > 0;
 
   return async (request: Request): Promise<Response> => {
@@ -89,12 +89,18 @@ export function createRehydraProxy(
       );
 
       if (overlappingSegments.length > 0) {
-        shouldCheckPathOverlap = false;
+        try {
+          const result = config.onPathOverlapWarning?.({
+            upstreamBaseUrl: upstream,
+            overlappingSegments,
+          });
 
-        config.onPathOverlapWarning?.({
-          upstreamBaseUrl: upstream,
-          overlappingSegments,
-        });
+          void Promise.resolve(result).catch(() => {
+            // Async callback failures must not interrupt proxying.
+          });
+        } catch {
+          // Synchronous callback failures must not interrupt proxying.
+        }
       }
     }
 

--- a/src/proxy/rehydra-proxy.ts
+++ b/src/proxy/rehydra-proxy.ts
@@ -54,9 +54,16 @@ export function createRehydraProxy(
 ): (request: Request) => Promise<Response> {
   const forwardHeaders = config.forwardHeaders ?? DEFAULT_FORWARD_HEADERS;
   const upstream = config.upstream.replace(/\/$/, ""); // Remove trailing slash
+  // Base path of the upstream, used only for overlap detection. Invalid upstream URL will throw at fetch time
+  const upstreamPathname = tryGetPathname(upstream);
+  const upstreamPathSegments = upstreamPathname.split("/").filter(Boolean);
 
   // Create the underlying Rehydra fetch wrapper
   const rehydraFetch = createRehydraFetch(config);
+
+  // Skip the per-request overlap check when there is no listener or upstream path segments, and stop checking after the first warning
+  let shouldCheckPathOverlap =
+    config.onPathOverlapWarning !== undefined && upstreamPathSegments.length > 0;
 
   return async (request: Request): Promise<Response> => {
     // Build upstream URL
@@ -72,6 +79,23 @@ export function createRehydraProxy(
     }
 
     const upstreamUrl = upstream + pathname + requestUrl.search;
+
+    // Detect overlapping path and warn
+    if (shouldCheckPathOverlap) {
+      const requestPathSegments = pathname.split("/").filter(Boolean);
+      const overlappingSegments = findPathSegmentOverlap(
+        upstreamPathSegments,
+        requestPathSegments,
+      );
+
+      if (overlappingSegments.length > 0) {
+        shouldCheckPathOverlap = false;
+
+        config.onPathOverlapWarning?.({
+          overlappingSegments,
+        });
+      }
+    }
 
     // Filter headers to forward
     const headers = new Headers();
@@ -110,4 +134,39 @@ export function createRehydraProxy(
       duplex: "half",
     });
   };
+}
+
+// Returns the URL's pathname, or an empty string if invalid
+function tryGetPathname(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return "";
+  }
+}
+
+// Finds the overlapping path segments between the upstream and request paths.
+function findPathSegmentOverlap(
+  upstreamSegments: string[],
+  requestSegments: string[],
+): string[] {
+  const maxOverlapLength = Math.min(
+    upstreamSegments.length,
+    requestSegments.length,
+  );
+
+  for (let length = maxOverlapLength; length > 0; length--) {
+    const upstreamSuffix = upstreamSegments.slice(-length);
+    const requestPrefix = requestSegments.slice(0, length);
+
+    const matches = upstreamSuffix.every(
+      (segment, index) => segment === requestPrefix[index],
+    );
+
+    if (matches) {
+      return upstreamSuffix;
+    }
+  }
+
+  return [];
 }

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -118,6 +118,9 @@ export interface RehydraFetchConfig {
  * Reported when the upstream base path and the incoming request path share segments
  */
 export interface PathOverlapWarning {
+  /** Configured upstream base URL with its trailing slash removed. */
+  upstreamBaseUrl: string;
+
   /**
    * Segments duplicated between the configured upstream suffix and the
    * incoming request prefix, e.g. ["api", "v1"].

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -115,6 +115,20 @@ export interface RehydraFetchConfig {
 }
 
 /**
+ * Reported when the upstream base path and the incoming request path share
+ * segments, meaning the forwarded URL repeats them (e.g. an upstream of
+ * `https://host/api/v1` plus a request to `/v1/chat/completions` is forwarded
+ * to `/api/v1/v1/chat/completions`).
+ */
+export interface PathOverlapWarning {
+  /**
+   * Segments duplicated between the configured upstream suffix and the
+   * incoming request prefix, e.g. ["api", "v1"].
+   */
+  overlappingSegments: string[];
+}
+
+/**
  * Configuration for the Rehydra proxy middleware
  */
 export interface RehydraProxyConfig extends RehydraFetchConfig {
@@ -139,4 +153,6 @@ export interface RehydraProxyConfig extends RehydraFetchConfig {
    * For OpenAI: sent as `Authorization: Bearer <key>`
    */
   apiKey?: string;
+
+  onPathOverlapWarning?: (warning: PathOverlapWarning) => void;
 }

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -115,10 +115,7 @@ export interface RehydraFetchConfig {
 }
 
 /**
- * Reported when the upstream base path and the incoming request path share
- * segments, meaning the forwarded URL repeats them (e.g. an upstream of
- * `https://host/api/v1` plus a request to `/v1/chat/completions` is forwarded
- * to `/api/v1/v1/chat/completions`).
+ * Reported when the upstream base path and the incoming request path share segments
  */
 export interface PathOverlapWarning {
   /**

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -154,5 +154,6 @@ export interface RehydraProxyConfig extends RehydraFetchConfig {
    */
   apiKey?: string;
 
-  onPathOverlapWarning?: (warning: PathOverlapWarning) => void;
+  /** Hook invoked for each request whose forwarded path overlaps the upstream base path */
+  onPathOverlapWarning?: (warning: PathOverlapWarning) => void | Promise<void>;
 }

--- a/test/cli/commands/proxy.test.ts
+++ b/test/cli/commands/proxy.test.ts
@@ -144,6 +144,25 @@ describe("proxy command", () => {
     });
 
     it.each([
+      "https://api.example.com/v1?query=param",
+      "https://api.example.com/v1#hash",
+      "https://api.example.com/v1?",
+      "https://api.example.com/v1#",
+    ]) ("should reject upstream with query or hash %s before init", async (upstream) => {
+      const result = proxyCommand(
+        "openai",
+        makeOptions({ upstream }),
+      );
+
+      await expect(result).rejects.toBeInstanceOf(CLIError);
+      await expect(result).rejects.toThrow(
+        `Invalid --upstream "${upstream}": must not include query parameters or hash fragment`,
+      );
+      expect(mockCreateRehydraProxy).not.toHaveBeenCalled();
+      expect(mockCreateServer).not.toHaveBeenCalled();
+    });
+
+    it.each([
       "https://api.example.com/v1",
       "http://localhost:8080/v1",
     ])("should accept absolute HTTP(S) upstream %s", async (upstream) => {
@@ -504,12 +523,42 @@ describe("proxy command", () => {
       const nerConfig = mockCreateRehydraProxy.mock.calls[1]![0];
 
       initialConfig.onPathOverlapWarning!(warning);
+      initialConfig.onPathOverlapWarning!(warning);
+      nerConfig.onPathOverlapWarning!(warning);
       nerConfig.onPathOverlapWarning!(warning);
 
       const matches = stderrChunks
         .join("")
         .match(/Warning: Upstream and incoming request path/g);
       expect(matches).toHaveLength(1);
+    });
+
+    it("prints again when a later request reveals a wider overlap", async () => {
+      const exitCode = await startAndShutdown(
+        "openai",
+        makeOptions({
+          upstream: "https://nano-gpt.com/api/v1",
+          quiet: false,
+        }),
+      );
+      expect(exitCode).toBe(0);
+
+      const config = mockCreateRehydraProxy.mock.calls[0]![0];
+
+      config.onPathOverlapWarning!(warning);
+      config.onPathOverlapWarning!({
+        upstreamBaseUrl: "https://nano-gpt.com/api/v1",
+        overlappingSegments: ["api", "v1"],
+      });
+
+      const output = stderrChunks.join("");
+      const matches = output.match(
+        /Warning: Upstream and incoming request path/g,
+      );
+      expect(matches).toHaveLength(2);
+      expect(output).toContain(
+        "overlap on /api/v1; forwarding to https://nano-gpt.com/api/v1/api/v1/...",
+      );
     });
   });
 

--- a/test/cli/commands/proxy.test.ts
+++ b/test/cli/commands/proxy.test.ts
@@ -33,6 +33,7 @@ vi.mock("../../../src/index.js", async (importOriginal) => {
 
 import { createServer } from "node:http";
 import { proxyCommand } from "../../../src/cli/commands/proxy.js";
+import { CLIError } from "../../../src/cli/utils/errors.js";
 import { createRehydraProxy } from "../../../src/proxy/index.js";
 import { isModelDownloaded, downloadModel } from "../../../src/index.js";
 
@@ -125,15 +126,34 @@ describe("proxy command", () => {
       ).rejects.toThrow("Unknown provider: gemini");
     });
 
-    it("should start with an upstream that is not an absolute URL", async () => {
+    it.each([
+      "api.example.com/v1",
+      "ftp://api.example.com/v1",
+    ])("should reject invalid upstream %s before initialization", async (upstream) => {
+      const result = proxyCommand(
+        "openai",
+        makeOptions({ upstream }),
+      );
+
+      await expect(result).rejects.toBeInstanceOf(CLIError);
+      await expect(result).rejects.toThrow(
+        `Invalid --upstream "${upstream}": expected an absolute http:// or https:// URL`,
+      );
+      expect(mockCreateRehydraProxy).not.toHaveBeenCalled();
+      expect(mockCreateServer).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      "https://api.example.com/v1",
+      "http://localhost:8080/v1",
+    ])("should accept absolute HTTP(S) upstream %s", async (upstream) => {
       const exitCode = await startAndShutdown(
         "openai",
-        makeOptions({ upstream: "api.example.com/v1" }),
+        makeOptions({ upstream }),
       );
+
       expect(exitCode).toBe(0);
-      expect(mockCreateRehydraProxy.mock.calls[0]![0].upstream).toBe(
-        "api.example.com/v1",
-      );
+      expect(mockCreateRehydraProxy.mock.calls[0]![0].upstream).toBe(upstream);
     });
 
     it("should throw for invalid port", async () => {
@@ -310,13 +330,64 @@ describe("proxy command", () => {
       expect(output).toContain("anthropic");
     });
 
-    it("should show openai connection hints for openai provider", async () => {
-      const exitCode = await startAndShutdown("openai", makeOptions({ quiet: false }));
+    it("should retain /v1 in all OpenAI hints for the default upstream", async () => {
+      const exitCode = await startAndShutdown(
+        "openai",
+        makeOptions({ quiet: false }),
+      );
       expect(exitCode).toBe(0);
       const output = stderrChunks.join("");
-      expect(output).toContain("OPENAI_BASE_URL");
-      expect(output).toContain("/v1");
-      expect(output).toContain("OpenAI SDK");
+      expect(output).toContain(
+        "export OPENAI_BASE_URL=http://127.0.0.1:8787/v1",
+      );
+      expect(output).toContain("    http://127.0.0.1:8787/v1");
+      expect(output).toContain(
+        'new OpenAI({ baseURL: "http://127.0.0.1:8787/v1" })',
+      );
+    });
+
+    it.each([
+      "https://api.example.com/api/v1",
+      "https://api.example.com/api/v1/",
+    ])("should use the proxy root in all OpenAI hints for upstream %s", async (upstream) => {
+      const exitCode = await startAndShutdown(
+        "openai",
+        makeOptions({ quiet: false, upstream }),
+      );
+      expect(exitCode).toBe(0);
+      const output = stderrChunks.join("");
+      expect(output).toContain(
+        "export OPENAI_BASE_URL=http://127.0.0.1:8787\n",
+      );
+      expect(output).toContain("    http://127.0.0.1:8787\n");
+      expect(output).toContain(
+        'new OpenAI({ baseURL: "http://127.0.0.1:8787" })',
+      );
+      expect(output).not.toContain(
+        'new OpenAI({ baseURL: "http://127.0.0.1:8787/v1" })',
+      );
+    });
+
+    it.each([
+      "https://api.example.com/api/v10",
+      "https://api.example.com/api/V1",
+    ])("should retain /v1 in all OpenAI hints for upstream %s", async (upstream) => {
+      const exitCode = await startAndShutdown(
+        "openai",
+        makeOptions({
+          quiet: false,
+          upstream,
+        }),
+      );
+      expect(exitCode).toBe(0);
+      const output = stderrChunks.join("");
+      expect(output).toContain(
+        "export OPENAI_BASE_URL=http://127.0.0.1:8787/v1",
+      );
+      expect(output).toContain("    http://127.0.0.1:8787/v1");
+      expect(output).toContain(
+        'new OpenAI({ baseURL: "http://127.0.0.1:8787/v1" })',
+      );
     });
 
     it("should show NER disabled when --ner disabled", async () => {
@@ -366,6 +437,7 @@ describe("proxy command", () => {
 
   describe("path overlap warnings", () => {
     const warning = {
+      upstreamBaseUrl: "https://nano-gpt.com/api/v1",
       overlappingSegments: ["v1"],
     };
 
@@ -373,7 +445,7 @@ describe("proxy command", () => {
       const exitCode = await startAndShutdown(
         "openai",
         makeOptions({
-          upstream: "https://nano-gpt.com/api/v1",
+          upstream: "https://nano-gpt.com/api/v1/",
           quiet: false,
         }),
       );
@@ -391,6 +463,11 @@ describe("proxy command", () => {
           "forwarding to https://nano-gpt.com/api/v1/v1/...\n" +
           "To fix, remove it from --upstream or the client base URL.\n",
       );
+      expect(output).not.toContain(
+        "https://nano-gpt.com/api/v1//v1/...",
+      );
+      expect(output).not.toContain("chat/completions");
+      expect(output).not.toContain("request_id=example");
     });
 
     it("does not wire the warning callback in quiet mode", async () => {

--- a/test/cli/commands/proxy.test.ts
+++ b/test/cli/commands/proxy.test.ts
@@ -148,7 +148,7 @@ describe("proxy command", () => {
       "https://api.example.com/v1#hash",
       "https://api.example.com/v1?",
       "https://api.example.com/v1#",
-    ]) ("should reject upstream with query or hash %s before init", async (upstream) => {
+    ])("should reject upstream with query or hash %s before init", async (upstream) => {
       const result = proxyCommand(
         "openai",
         makeOptions({ upstream }),

--- a/test/cli/commands/proxy.test.ts
+++ b/test/cli/commands/proxy.test.ts
@@ -125,6 +125,17 @@ describe("proxy command", () => {
       ).rejects.toThrow("Unknown provider: gemini");
     });
 
+    it("should start with an upstream that is not an absolute URL", async () => {
+      const exitCode = await startAndShutdown(
+        "openai",
+        makeOptions({ upstream: "api.example.com/v1" }),
+      );
+      expect(exitCode).toBe(0);
+      expect(mockCreateRehydraProxy.mock.calls[0]![0].upstream).toBe(
+        "api.example.com/v1",
+      );
+    });
+
     it("should throw for invalid port", async () => {
       await expect(
         proxyCommand("claude", makeOptions({ port: "abc" })),
@@ -348,6 +359,80 @@ describe("proxy command", () => {
       const exitCode = await startAndShutdown("claude", makeOptions({ quiet: true }));
       expect(exitCode).toBe(0);
       expect(stderrChunks.join("")).not.toContain("Shutting down");
+    });
+  });
+
+  // --- Path overlap warnings ---
+
+  describe("path overlap warnings", () => {
+    const warning = {
+      overlappingSegments: ["v1"],
+    };
+
+    it("wires an actionable warning callback when output is enabled", async () => {
+      const exitCode = await startAndShutdown(
+        "openai",
+        makeOptions({
+          upstream: "https://nano-gpt.com/api/v1",
+          quiet: false,
+        }),
+      );
+      expect(exitCode).toBe(0);
+
+      const config = mockCreateRehydraProxy.mock.calls[0]![0];
+      expect(config.onPathOverlapWarning).toBeTypeOf("function");
+
+      config.onPathOverlapWarning!(warning);
+
+      const output = stderrChunks.join("");
+      expect(output).toContain("Warning:");
+      expect(output).toContain(
+        "Warning: Upstream and incoming request path overlap on /v1; " +
+          "forwarding to https://nano-gpt.com/api/v1/v1/...\n" +
+          "To fix, remove it from --upstream or the client base URL.\n",
+      );
+    });
+
+    it("does not wire the warning callback in quiet mode", async () => {
+      const exitCode = await startAndShutdown(
+        "openai",
+        makeOptions({
+          upstream: "https://nano-gpt.com/api/v1",
+          quiet: true,
+        }),
+      );
+      expect(exitCode).toBe(0);
+
+      const config = mockCreateRehydraProxy.mock.calls[0]![0];
+      expect(config.onPathOverlapWarning).toBeUndefined();
+    });
+
+    it("prints once across the initial and NER-enabled proxies", async () => {
+      mockIsModelDownloaded.mockResolvedValue(true);
+      const exitCode = await startAndShutdown(
+        "openai",
+        makeOptions({
+          upstream: "https://nano-gpt.com/api/v1",
+          ner: "quantized",
+          quiet: false,
+        }),
+      );
+      expect(exitCode).toBe(0);
+
+      await vi.waitFor(() => {
+        expect(mockCreateRehydraProxy).toHaveBeenCalledTimes(2);
+      });
+
+      const initialConfig = mockCreateRehydraProxy.mock.calls[0]![0];
+      const nerConfig = mockCreateRehydraProxy.mock.calls[1]![0];
+
+      initialConfig.onPathOverlapWarning!(warning);
+      nerConfig.onPathOverlapWarning!(warning);
+
+      const matches = stderrChunks
+        .join("")
+        .match(/Warning: Upstream and incoming request path/g);
+      expect(matches).toHaveLength(1);
     });
   });
 

--- a/test/cli/main.test.ts
+++ b/test/cli/main.test.ts
@@ -88,6 +88,7 @@ describe("run()", () => {
     expect(output).toContain("proxy <provider>");
     expect(output).toContain("--port");
     expect(output).toContain("--upstream");
+    expect(output).toContain("Absolute HTTP(S) upstream URL");
   });
 
   it("should dispatch proxy command (missing provider error)", async () => {

--- a/test/proxy/rehydra-proxy.test.ts
+++ b/test/proxy/rehydra-proxy.test.ts
@@ -37,7 +37,7 @@ describe("createRehydraProxy path overlap warning", () => {
     const warnings: PathOverlapWarning[] = [];
     const proxy = createRehydraProxy(
       makeConfig({
-        upstream: "https://nano-gpt.com/api/v1",
+        upstream: "https://nano-gpt.com/api/v1/",
         onPathOverlapWarning: (warning) => warnings.push(warning),
       }),
     );
@@ -50,9 +50,13 @@ describe("createRehydraProxy path overlap warning", () => {
 
     expect(warnings).toEqual([
       {
+        upstreamBaseUrl: "https://nano-gpt.com/api/v1",
         overlappingSegments: ["v1"],
       },
     ]);
+    const warningPayload = JSON.stringify(warnings[0]);
+    expect(warningPayload).not.toContain("chat/completions");
+    expect(warningPayload).not.toContain("request_id=example");
     expect(mockRehydraFetch).toHaveBeenCalledWith(
       "https://nano-gpt.com/api/v1/v1/chat/completions?request_id=example",
       expect.any(Object),

--- a/test/proxy/rehydra-proxy.test.ts
+++ b/test/proxy/rehydra-proxy.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { InMemoryKeyProvider } from "../../src/crypto/pii-map-crypto.js";
+import { createRehydraProxy } from "../../src/proxy/rehydra-proxy.js";
+import type {
+  PathOverlapWarning,
+  RehydraProxyConfig,
+} from "../../src/proxy/types.js";
+import { InMemoryPIIStorageProvider } from "../../src/storage/in-memory.js";
+
+const { mockRehydraFetch } = vi.hoisted(() => ({
+  mockRehydraFetch: vi.fn<typeof globalThis.fetch>(),
+}));
+
+vi.mock("../../src/proxy/rehydra-fetch.js", () => ({
+  createRehydraFetch: vi.fn(() => mockRehydraFetch),
+}));
+
+function makeConfig(
+  overrides: Partial<RehydraProxyConfig> = {},
+): RehydraProxyConfig {
+  return {
+    upstream: "https://api.openai.com",
+    provider: "openai",
+    keyProvider: new InMemoryKeyProvider(),
+    piiStorageProvider: new InMemoryPIIStorageProvider(),
+    ...overrides,
+  };
+}
+
+describe("createRehydraProxy path overlap warning", () => {
+  beforeEach(() => {
+    mockRehydraFetch.mockReset();
+    mockRehydraFetch.mockResolvedValue(new Response(null, { status: 204 }));
+  });
+
+  it("should warn for the duplicated /v1 path from issue #77", async () => {
+    const warnings: PathOverlapWarning[] = [];
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://nano-gpt.com/api/v1",
+        onPathOverlapWarning: (warning) => warnings.push(warning),
+      }),
+    );
+
+    await proxy(
+      new Request(
+        "http://127.0.0.1:8788/v1/chat/completions?request_id=example",
+      ),
+    );
+
+    expect(warnings).toEqual([
+      {
+        overlappingSegments: ["v1"],
+      },
+    ]);
+    expect(mockRehydraFetch).toHaveBeenCalledWith(
+      "https://nano-gpt.com/api/v1/v1/chat/completions?request_id=example",
+      expect.any(Object),
+    );
+  });
+
+  it("should report the longest overlap when multiple path segments match", async () => {
+    const warnings: PathOverlapWarning[] = [];
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://example.com/proxy/api/v1",
+        onPathOverlapWarning: (warning) => warnings.push(warning),
+      }),
+    );
+
+    await proxy(
+      new Request("http://127.0.0.1:8788/api/v1/chat/completions"),
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.overlappingSegments).toEqual(["api", "v1"]);
+  });
+
+  it("should not warn when only non-boundary path segments match", async () => {
+    const onPathOverlapWarning = vi.fn();
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://example.com/api/v1",
+        onPathOverlapWarning,
+      }),
+    );
+
+    await proxy(
+      new Request("http://127.0.0.1:8788/api/v2/chat/completions"),
+    );
+
+    expect(onPathOverlapWarning).not.toHaveBeenCalled();
+  });
+
+  it("should compare complete path segments instead of partial strings", async () => {
+    const onPathOverlapWarning = vi.fn();
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://example.com/v1",
+        onPathOverlapWarning,
+      }),
+    );
+
+    await proxy(
+      new Request("http://127.0.0.1:8788/v10/chat/completions"),
+    );
+
+    expect(onPathOverlapWarning).not.toHaveBeenCalled();
+  });
+
+  it("should not warn when the upstream has no base path", async () => {
+    const onPathOverlapWarning = vi.fn();
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://api.openai.com",
+        onPathOverlapWarning,
+      }),
+    );
+
+    await proxy(
+      new Request("http://127.0.0.1:8788/v1/chat/completions"),
+    );
+
+    expect(onPathOverlapWarning).not.toHaveBeenCalled();
+  });
+
+  it("should check the pathname after stripPrefix is applied", async () => {
+    const onPathOverlapWarning = vi.fn();
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://example.com/api",
+        stripPrefix: "/api",
+        onPathOverlapWarning,
+      }),
+    );
+
+    await proxy(
+      new Request("http://127.0.0.1:8788/api/v1/chat/completions"),
+    );
+
+    expect(onPathOverlapWarning).not.toHaveBeenCalled();
+    expect(mockRehydraFetch).toHaveBeenCalledWith(
+      "https://example.com/api/v1/chat/completions",
+      expect.any(Object),
+    );
+  });
+
+  it("should skip overlap detection when the upstream is not an absolute URL", async () => {
+    const onPathOverlapWarning = vi.fn();
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "api.example.com/v1",
+        onPathOverlapWarning,
+      }),
+    );
+
+    await proxy(
+      new Request("http://127.0.0.1:8788/v1/chat/completions"),
+    );
+
+    expect(onPathOverlapWarning).not.toHaveBeenCalled();
+    expect(mockRehydraFetch).toHaveBeenCalledWith(
+      "api.example.com/v1/v1/chat/completions",
+      expect.any(Object),
+    );
+  });
+
+  it("should warn only once for repeated overlapping requests", async () => {
+    const onPathOverlapWarning = vi.fn();
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://example.com/v1",
+        onPathOverlapWarning,
+      }),
+    );
+
+    await proxy(
+      new Request("http://127.0.0.1:8788/v1/chat/completions"),
+    );
+    await proxy(
+      new Request("http://127.0.0.1:8788/v1/embeddings"),
+    );
+
+    expect(onPathOverlapWarning).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/proxy/rehydra-proxy.test.ts
+++ b/test/proxy/rehydra-proxy.test.ts
@@ -38,7 +38,9 @@ describe("createRehydraProxy path overlap warning", () => {
     const proxy = createRehydraProxy(
       makeConfig({
         upstream: "https://nano-gpt.com/api/v1/",
-        onPathOverlapWarning: (warning) => warnings.push(warning),
+        onPathOverlapWarning: (warning) => {
+          warnings.push(warning);
+        },
       }),
     );
 
@@ -68,7 +70,9 @@ describe("createRehydraProxy path overlap warning", () => {
     const proxy = createRehydraProxy(
       makeConfig({
         upstream: "https://example.com/proxy/api/v1",
-        onPathOverlapWarning: (warning) => warnings.push(warning),
+        onPathOverlapWarning: (warning) => {
+          warnings.push(warning);
+        },
       }),
     );
 
@@ -169,7 +173,7 @@ describe("createRehydraProxy path overlap warning", () => {
     );
   });
 
-  it("should warn only once for repeated overlapping requests", async () => {
+  it("should warn for every overlapping request", async () => {
     const onPathOverlapWarning = vi.fn();
     const proxy = createRehydraProxy(
       makeConfig({
@@ -185,6 +189,127 @@ describe("createRehydraProxy path overlap warning", () => {
       new Request("http://127.0.0.1:8788/v1/embeddings"),
     );
 
-    expect(onPathOverlapWarning).toHaveBeenCalledTimes(1);
+    expect(onPathOverlapWarning).toHaveBeenCalledTimes(2);
   });
+
+  it("should report a wider overlap found on a later request", async () => {
+    const onPathOverlapWarning = vi.fn();
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://example.com/api/v1",
+        onPathOverlapWarning,
+      }),
+    );
+
+    await proxy(
+      new Request("http://127.0.0.1:8788/v1/chat/completions"),
+    );
+    await proxy(
+      new Request("http://127.0.0.1:8788/api/v1/embeddings"),
+    );
+
+    expect(onPathOverlapWarning).toHaveBeenNthCalledWith(1, {
+      upstreamBaseUrl: "https://example.com/api/v1",
+      overlappingSegments: ["v1"],
+    });
+    expect(onPathOverlapWarning).toHaveBeenNthCalledWith(2, {
+      upstreamBaseUrl: "https://example.com/api/v1",
+      overlappingSegments: ["api", "v1"],
+    });
+  });
+
+  it("should continue proxying when the warning callback throws", async () => {
+    const proxy = createRehydraProxy(
+      makeConfig({
+        upstream: "https://example.com/v1",
+        onPathOverlapWarning: () => {
+          throw new Error("warning callback failed");
+        },
+      }),
+    );
+
+    const response = await proxy(
+      new Request("http://127.0.0.1:8788/v1/chat/completions"),
+    );
+
+    expect(response.status).toBe(204);
+    expect(mockRehydraFetch).toHaveBeenCalledWith(
+      "https://example.com/v1/v1/chat/completions",
+      expect.any(Object),
+    );
+  });
+
+  it("should continue proxying when an async warning callback rejects", async () => {
+    let rejectWarningCallback: (reason: Error) => void = () => {};
+    const warningCallbackResult = new Promise<void>((_resolve, reject) => {
+      rejectWarningCallback = reject;
+    });
+    const onUnhandledRejection = vi.fn();
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const proxy = createRehydraProxy(
+        makeConfig({
+          upstream: "https://example.com/v1",
+          onPathOverlapWarning: () => warningCallbackResult,
+        }),
+      );
+
+      const response = await proxy(
+        new Request("http://127.0.0.1:8788/v1/chat/completions"),
+      );
+
+      expect(response.status).toBe(204);
+      expect(mockRehydraFetch).toHaveBeenCalledWith(
+        "https://example.com/v1/v1/chat/completions",
+        expect.any(Object),
+      );
+
+      rejectWarningCallback(new Error("async warning callback failed"));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(onUnhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  // The callback returns an already-rejected promise, so the rejection is only
+  // handled if the proxy attaches its catch before the microtask checkpoint
+  it("should continue proxying when an async warning callback throws", async () => {
+    const onUnhandledRejection = vi.fn();
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const proxy = createRehydraProxy(
+        makeConfig({
+          upstream: "https://example.com/v1",
+          onPathOverlapWarning: async () => {
+            throw new Error("async warning callback failed");
+          },
+        }),
+      );
+
+      const response = await proxy(
+        new Request("http://127.0.0.1:8788/v1/chat/completions"),
+      );
+
+      expect(response.status).toBe(204);
+      expect(mockRehydraFetch).toHaveBeenCalledWith(
+        "https://example.com/v1/v1/chat/completions",
+        expect.any(Object),
+      );
+
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(onUnhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
 });

--- a/test/proxy/rehydra-proxy.test.ts
+++ b/test/proxy/rehydra-proxy.test.ts
@@ -76,7 +76,7 @@ describe("createRehydraProxy path overlap warning", () => {
     expect(warnings[0]?.overlappingSegments).toEqual(["api", "v1"]);
   });
 
-  it("should not warn when only non-boundary path segments match", async () => {
+  it("should not warn when a shared segment does not overlap at the join boundary", async () => {
     const onPathOverlapWarning = vi.fn();
     const proxy = createRehydraProxy(
       makeConfig({


### PR DESCRIPTION
Fixes #77 

## Background

The proxy builds the forwarding URL by appending the incoming pathname to the `--upstream` URL, which can cause problems where the two have overlapping path segment(s), such as:

```sh
... --upstream https://example.com/api/v1
```

and then setting the incoming url as `http://127.0.0.1:8788/v1/chat/completions`, which will forward the call to:

```sh
https://example.com/api/v1/v1/chat/completions`
```

This will not impact anonymization, but the upstream call will likely 404.

## Fix

Detect when the suffix of the upstream base path overlaps with the prefix of the incoming request path, then surface an actionable warning without changing routing behavior.

- Compare complete path segments and report the longest matching overlap
- Run detection after `stripPrefix` has been applied
- Add an optional `onPathOverlapWarning` callback to `RehydraProxyConfig`
- Export the new `PathOverlapWarning` type from the proxy package
- Print the CLI warning only once per session
  - In case the duplication is intentional, no need to spam the warning
- Suppress the warning with `--quiet`
  - Same reasoning as point above
- Avoid logging the full incoming request path or query parameters
  - This is to prevent accidental PII being logged if it's part of the path or query
- Skip detection for upstreams without a base path or that cannot be parsed as absolute URLs

The warning recommends removing the duplicated segment from either `--upstream` or the client base URL.

## Verification

- Added proxy tests covering:
  - The exact duplicated `/v1` reproduction from #77 / #74
  - Multi-segment overlaps and longest-match selection
  - Non-boundary and partial-string matches
  - Upstreams without base paths
  - Detection after `stripPrefix`
  - Non-absolute upstream values
  - Warning only once across repeated requests
- Added CLI tests covering
  - Actionable warning output
  - `--quiet` behavior
  - Warning only once across initial and NER-enabled proxy instances
- Focused proxy and CLI suites pass: 60 tests
- `build`, `lint`, and `test:run` all pass on node 18, 20, and 22

## Notes

This is intentionally non-breaking: the forwarded URL is unchanged and the SDK only reports the likely configuration mistake.

The separate streaming `createRehydraProxyServer` end-to-end test gap noted in #77 is outside the scope of this change. I'm happy to open a new issue for tracking this, just let me know!