### PR TITLE
feat: support alphanumeric tag IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,26 @@ Purpose-built for LLM token streams. A sentence-buffered chunking system with NE
 
 Optional gender and scope attributes on PII tags (`<PII type="PERSON" gender="male" id="1"/>`, `<PII type="LOCATION" scope="city" id="2"/>`) preserve grammatical context for downstream systems.
 
+### Stable external tag IDs
+
+Callers that manage PII maps across independent anonymization calls can seed lowercase alphanumeric IDs through `existingPiiMap`. This allows an ID to be derived from the value it masks, for example with a keyed HMAC, instead of depending on a per-call counter.
+
+```typescript
+const existingPiiMap = new Map([
+  ['EMAIL_a4f2c9d8e7b6q', 'alice@acme.com'],
+]);
+
+const result = await anonymizer.anonymize(
+  'Email alice@acme.com',
+  undefined,
+  policy,
+  existingPiiMap,
+);
+// → 'Email <PII type="EMAIL" id="a4f2c9d8e7b6q"/>'
+```
+
+External IDs must match `[0-9a-z]+`. Decimal-only IDs retain their existing numeric behavior. Avoid IDs beginning with recognizer prefixes such as `case`, `file`, `ref`, or `ticket`, and avoid runs of seven or more digits; those shapes may themselves be detected as case IDs or phone numbers inside an inbound tag.
+
 ## Example: Full Round-Trip with Sessions
 
 ```typescript

--- a/src/cli/commands/anonymize.ts
+++ b/src/cli/commands/anonymize.ts
@@ -5,6 +5,7 @@ import {
   type NERConfig,
   type SecretsConfig,
   type AnonymizationPolicy,
+  type TagId,
   PIIType,
   mergePolicy,
   generateKey,
@@ -251,7 +252,7 @@ async function anonymizeFile(
   policy: Partial<AnonymizationPolicy> | undefined,
 ): Promise<number> {
   const countsByType: Record<string, number> = {};
-  const allEntities: { type: string; id: number; confidence: number; source: string; semantic?: unknown }[] = [];
+  const allEntities: { type: string; id: TagId; confidence: number; source: string; semantic?: unknown }[] = [];
   const textChunks: string[] = [];
   let finishData: StreamFinishEvent | undefined;
 

--- a/src/pipeline/tagger.ts
+++ b/src/pipeline/tagger.ts
@@ -10,10 +10,31 @@ import {
   AnonymizationPolicy,
   SemanticAttributes,
   TagFormat,
+  TagId,
   DEFAULT_TAG_FORMAT,
 } from "../types/index.js";
 import { sortSpansByPosition } from "../utils/offsets.js";
 import { escapeRegExp } from "../utils/regex.js";
+
+/**
+ * Character class for tag IDs.
+ *
+ * Lowercase alphanumerics only: decimal digits keep counter-assigned IDs
+ * working unchanged, while letters give callers enough space to seed
+ * value-derived IDs without relying on long decimal strings. Uppercase is
+ * excluded so a PII map key `${TYPE}_${id}` stays unambiguous — types are
+ * `[A-Z_]+` and may themselves contain underscores.
+ */
+const ID_CHARS = "[0-9a-z]+";
+
+/**
+ * Converts a raw id attribute value into a {@link TagId}.
+ * Decimal-only IDs become numbers (preserving the existing numeric API);
+ * everything else is folded to a lowercase string.
+ */
+function parseTagId(raw: string): TagId {
+  return /^[0-9]+$/.test(raw) ? parseInt(raw, 10) : raw.toLowerCase();
+}
 
 /**
  * PII Map entry (before encryption)
@@ -22,7 +43,7 @@ export interface PIIMapEntry {
   /** PII type */
   type: PIIType;
   /** Entity ID */
-  id: number;
+  id: TagId;
   /** Original text */
   original: string;
 }
@@ -54,7 +75,7 @@ export interface TaggingResult {
  */
 export function generateTag(
   type: PIIType,
-  id: number,
+  id: TagId,
   semantic?: SemanticAttributes,
   tagFormat: TagFormat = DEFAULT_TAG_FORMAT
 ): string {
@@ -79,7 +100,7 @@ export function generateTag(
  */
 export interface ParsedTag {
   type: PIIType;
-  id: number;
+  id: TagId;
   semantic?: SemanticAttributes;
 }
 
@@ -103,7 +124,7 @@ export function parseTag(
   // Build regex dynamically from tag format
   const match = tag.match(
     new RegExp(
-      `^${open}${escapeRegExp(keyword)}\\s+type="([A-Z_]+)"(?:\\s+gender="(\\w+)")?(?:\\s+scope="([\\w-]+)")?\\s+id="(\\d+)"\\s*${close}$`
+      `^${open}${escapeRegExp(keyword)}\\s+type="([A-Z_]+)"(?:\\s+gender="(\\w+)")?(?:\\s+scope="([\\w-]+)")?\\s+id="(${ID_CHARS})"\\s*${close}$`
     )
   );
 
@@ -120,7 +141,7 @@ export function parseTag(
   // may emit types that are not members of the PIIType enum. Downstream code
   // treats `type` as an opaque string when building PII map keys.
   const type = typeStr as PIIType;
-  const id = parseInt(idStr, 10);
+  const id = parseTagId(idStr);
 
   // Build semantic attributes if present
   let semantic: SemanticAttributes | undefined;
@@ -151,7 +172,7 @@ export function parseTag(
 /**
  * Creates a key for the PII map
  */
-export function createPIIMapKey(type: PIIType, id: number): string {
+export function createPIIMapKey(type: PIIType, id: TagId): string {
   return `${type}_${id}`;
 }
 
@@ -160,28 +181,28 @@ export function createPIIMapKey(type: PIIType, id: number): string {
  * @param key - Key in format "TYPE_ID" (e.g., "PERSON_1")
  * @returns Parsed type and id, or null if invalid
  */
-function parsePIIMapKey(key: string): { type: PIIType; id: number } | null {
-  const match = key.match(/^([A-Z_]+)_(\d+)$/);
+function parsePIIMapKey(key: string): { type: PIIType; id: TagId } | null {
+  const match = key.match(new RegExp(`^([A-Z_]+)_(${ID_CHARS})$`));
   if (!match || match[1] === undefined || match[2] === undefined) {
     return null;
   }
   // Allow any [A-Z_]+ type — matches what parseTag accepts, so custom-type
   // entries survive `buildExistingEntityLookup` and session-level ID reuse.
   const type = match[1] as PIIType;
-  const id = parseInt(match[2], 10);
+  const id = parseTagId(match[2]);
   return { type, id };
 }
 
 /**
  * Builds a reverse lookup and max ID from an existing PII map
  * @param existingPiiMap - Existing PII map (key → value)
- * @returns Reverse lookup (type:value → id) and global max ID
+ * @returns Reverse lookup (type:value → id) and global max numeric ID
  */
 function buildExistingEntityLookup(existingPiiMap: RawPIIMap): {
-  reverseLookup: Map<string, number>;
+  reverseLookup: Map<string, TagId>;
   maxId: number;
 } {
-  const reverseLookup = new Map<string, number>(); // "TYPE:value" → id
+  const reverseLookup = new Map<string, TagId>(); // "TYPE:value" → id
   let maxId = 0;
 
   for (const [key, value] of existingPiiMap) {
@@ -191,8 +212,9 @@ function buildExistingEntityLookup(existingPiiMap: RawPIIMap): {
       const lookupKey = `${parsed.type}:${value}`;
       reverseLookup.set(lookupKey, parsed.id);
 
-      // Track global max ID
-      if (parsed.id > maxId) {
+      // Track global max ID. Only numeric IDs feed the counter — an
+      // alphanumeric ID has no successor, so it must not affect `nextId`.
+      if (typeof parsed.id === "number" && parsed.id > maxId) {
         maxId = parsed.id;
       }
     }
@@ -230,19 +252,19 @@ export function tagEntities(
   // Build lookup from existing PII map (if provided)
   const { reverseLookup, maxId } = existingPiiMap
     ? buildExistingEntityLookup(existingPiiMap)
-    : { reverseLookup: new Map<string, number>(), maxId: 0 };
+    : { reverseLookup: new Map<string, TagId>(), maxId: 0 };
 
   // Assign IDs
-  const entitiesWithIds: Array<SpanMatch & { id: number }> = [];
+  const entitiesWithIds: Array<SpanMatch & { id: TagId }> = [];
 
   // Global ID counter (starts from max existing + 1)
   let nextId = maxId + 1;
 
   // Track seen text for ID reuse within this call (if enabled)
-  const seenText = new Map<string, number>(); // "type:text" -> id
+  const seenText = new Map<string, TagId>(); // "type:text" -> id
 
   for (const match of sortedAscending) {
-    let id: number;
+    let id: TagId;
     const lookupKey = `${match.type}:${match.text}`;
 
     // First, check if this value exists in the existing PII map (session-level reuse)
@@ -324,7 +346,7 @@ export function isValidTag(
  */
 export interface ExtractedTag {
   type: PIIType;
-  id: number;
+  id: TagId;
   position: number;
   /** The actual matched text (needed for replacement when tag is mangled) */
   matchedText: string;
@@ -456,7 +478,7 @@ function buildFuzzyTagPatterns(
   const typeAttr = `type${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}([A-Z_]+)${QUOTE_CHARS}`;
   // Pattern for id attribute: id = "VALUE" (flexible spacing and quotes)
   // Also handles malformed cases where close delimiter got placed inside the quotes
-  const idAttr = `id${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}(\\d+)${idCloseLeak}${QUOTE_CHARS}`;
+  const idAttr = `id${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}(${ID_CHARS})${idCloseLeak}${QUOTE_CHARS}`;
   // Optional gender attribute
   const genderAttr = `(?:${FLEXIBLE_WS}gender${FLEXIBLE_WS}=${FLEXIBLE_WS}${QUOTE_CHARS}(\\w+)${QUOTE_CHARS})?`;
   // Optional scope attribute
@@ -540,7 +562,9 @@ export function extractTags(
         // createCustomIdRecognizer may emit types that are not PIIType enum
         // members; rehydrate() must still be able to restore them.
         const type = typeStr.toUpperCase() as PIIType;
-        const id = parseInt(idStr, 10);
+        // Fuzzy matching is case-insensitive, so fold the id back to lowercase
+        // (lossless: ids never contain uppercase).
+        const id = parseTagId(idStr);
 
         // Build semantic attributes if present
         let semantic: SemanticAttributes | undefined;
@@ -604,7 +628,7 @@ export function extractTagsStrict(
   const close = escapeRegExp(tagFormat.close);
   // Pattern matches: OPEN KEYWORD type="X" [gender="Y"] [scope="Z"] id="N" CLOSE
   const tagPattern = new RegExp(
-    `${open}${escapeRegExp(keyword)}\\s+type="([A-Z_]+)"(?:\\s+gender="(\\w+)")?(?:\\s+scope="([\\w-]+)")?\\s+id="(\\d+)"\\s*${close}`,
+    `${open}${escapeRegExp(keyword)}\\s+type="([A-Z_]+)"(?:\\s+gender="(\\w+)")?(?:\\s+scope="([\\w-]+)")?\\s+id="(${ID_CHARS})"\\s*${close}`,
     "g"
   );
 
@@ -618,7 +642,7 @@ export function extractTagsStrict(
     if (typeStr !== undefined && idStr !== undefined) {
       // Accept any [A-Z_]+ type (see extractTags for rationale).
       const type = typeStr as PIIType;
-      const id = parseInt(idStr, 10);
+      const id = parseTagId(idStr);
 
       // Build semantic attributes if present
       let semantic: SemanticAttributes | undefined;

--- a/src/pipeline/validator.ts
+++ b/src/pipeline/validator.ts
@@ -3,7 +3,7 @@
  * Validates anonymized output and performs leak scan
  */
 
-import { PIIType, DetectedEntity, AnonymizationPolicy, TagFormat, DEFAULT_TAG_FORMAT } from '../types/index.js';
+import { PIIType, DetectedEntity, AnonymizationPolicy, TagFormat, TagId, DEFAULT_TAG_FORMAT } from '../types/index.js';
 import { spansOverlap } from '../utils/offsets.js';
 import { extractTags, isValidTag } from './tagger.js';
 import { escapeRegExp } from '../utils/regex.js';
@@ -182,7 +182,7 @@ function checkOverlappingEntities(entities: DetectedEntity[]): ValidationError[]
  */
 function checkUniqueIds(entities: DetectedEntity[]): ValidationError[] {
   const errors: ValidationError[] = [];
-  const seenIds = new Map<number, DetectedEntity>();
+  const seenIds = new Map<TagId, DetectedEntity>();
 
   for (const entity of entities) {
     const existing = seenIds.get(entity.id);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,13 +116,24 @@ export interface SemanticConfig {
 }
 
 /**
+ * Identifier of a PII tag.
+ *
+ * IDs assigned by the tagger are 1-based, monotonically increasing numbers.
+ * Externally generated IDs (e.g. seeded through an existing PII map) may also
+ * be lowercase alphanumeric strings (`[0-9a-z]+`), which lets callers derive a
+ * stable ID from the value it masks. Decimal-only IDs are always represented
+ * as numbers; any ID containing letters is represented as a lowercase string.
+ */
+export type TagId = number | string;
+
+/**
  * A detected PII entity with its position and metadata
  */
 export interface DetectedEntity {
   /** PII category */
   type: PIIType;
-  /** Unique identifier within the document (1-based, monotonically increasing) */
-  id: number;
+  /** Unique identifier within the document (see {@link TagId}) */
+  id: TagId;
   /** Start character offset in original text (0-based, inclusive) */
   start: number;
   /** End character offset in original text (0-based, exclusive) */

--- a/test/integration/anonymizer.test.ts
+++ b/test/integration/anonymizer.test.ts
@@ -11,6 +11,7 @@ import {
   InMemoryKeyProvider,
   InMemoryPIIStorageProvider,
   decryptPIIMap,
+  rehydrate,
 } from '../../src/index.js';
 
 describe('Anonymizer Integration', () => {
@@ -727,3 +728,63 @@ describe('custom type round-trip (issue #68)', () => {
   });
 });
 
+describe('alphanumeric tag ids (issue #91)', () => {
+  // Regression test for https://github.com/rehydra-ai/rehydra-sdk/issues/91
+  // Callers may seed value-derived, lowercase alphanumeric ids through an
+  // existing PII map. Those ids must survive anonymize → rehydrate, must not
+  // be mangled by numeric recognizers, and must not disturb the numeric counter.
+  const policy = {
+    enabledTypes: new Set([PIIType.EMAIL, PIIType.CREDIT_CARD, PIIType.PHONE]),
+    regexEnabledTypes: new Set([PIIType.EMAIL, PIIType.CREDIT_CARD, PIIType.PHONE]),
+    reuseIdsForRepeatedPII: true,
+  };
+
+  it('reuses a seeded alphanumeric id and leaves the numeric counter intact', async () => {
+    const anon = createAnonymizer({
+      ner: { mode: 'disabled' },
+      keyProvider: new InMemoryKeyProvider(),
+    });
+    await anon.initialize();
+
+    const existing = new Map<string, string>([
+      ['EMAIL_k9m2p7', 'alice@acme.com'],
+      ['EMAIL_4', 'carol@acme.com'],
+    ]);
+    const result = await anon.anonymize(
+      'Reach alice@acme.com or bob@acme.com',
+      undefined,
+      policy,
+      existing
+    );
+
+    expect(result.anonymizedText).toBe(
+      'Reach <PII type="EMAIL" id="k9m2p7"/> or <PII type="EMAIL" id="5"/>'
+    );
+    expect(result.entities.map((e) => e.id)).toEqual(['k9m2p7', 5]);
+  });
+
+  it('does not destroy an alphanumeric tag with numeric recognizers', async () => {
+    // A long decimal id may be matched by the credit-card / phone recognizers
+    // (see the issue). A mixed id without long digit runs avoids that conflict.
+    const text = 'Earlier: <PII type="PERSON" id="a4f2c9d8e7b6q"/>';
+    const result = await anonymizeRegexOnly(text, policy);
+    expect(result.anonymizedText).toBe(text);
+    expect(result.entities).toHaveLength(0);
+  });
+
+  it('round-trips an alphanumeric id through anonymize and rehydrate', async () => {
+    const keyProvider = new InMemoryKeyProvider();
+    const anon = createAnonymizer({ ner: { mode: 'disabled' }, keyProvider });
+    await anon.initialize();
+
+    const existing = new Map<string, string>([['EMAIL_k9m2p7', 'alice@acme.com']]);
+    const result = await anon.anonymize('Reach alice@acme.com', undefined, policy, existing);
+    expect(result.anonymizedText).toBe('Reach <PII type="EMAIL" id="k9m2p7"/>');
+
+    const piiMap = await decryptPIIMap(result.piiMap, await keyProvider.getKey());
+    expect(piiMap.get('EMAIL_k9m2p7')).toBe('alice@acme.com');
+    expect(rehydrate(result.anonymizedText, piiMap)).toBe('Reach alice@acme.com');
+    // Case-mangled by a model: still resolves.
+    expect(rehydrate('Reach <PII type="EMAIL" id="K9M2P7"/>', piiMap)).toBe('Reach alice@acme.com');
+  });
+});

--- a/test/pipeline/tagger.test.ts
+++ b/test/pipeline/tagger.test.ts
@@ -1381,4 +1381,231 @@ describe("Tagger", () => {
       expect(second.anonymizedText).toBe('pay <PII type="AMOUNT" id="1"/> again');
     });
   });
+
+  // =========================================================================
+  // Alphanumeric tag ids (GitHub issue #91)
+  // =========================================================================
+  describe("alphanumeric tag ids (issue #91)", () => {
+    const span = (type: PIIType, text: string, start: number): SpanMatch => ({
+      type,
+      text,
+      start,
+      end: start + text.length,
+      confidence: 0.9,
+      source: DetectionSource.REGEX,
+    });
+
+    describe("generateTag / createPIIMapKey", () => {
+      it("should accept string ids", () => {
+        expect(generateTag(PIIType.PERSON, "a4f2c9")).toBe(
+          '<PII type="PERSON" id="a4f2c9"/>'
+        );
+        expect(createPIIMapKey(PIIType.PERSON, "a4f2c9")).toBe("PERSON_a4f2c9");
+      });
+
+      it("should still accept numeric ids unchanged", () => {
+        expect(generateTag(PIIType.PERSON, 7)).toBe('<PII type="PERSON" id="7"/>');
+        expect(createPIIMapKey(PIIType.PERSON, 7)).toBe("PERSON_7");
+      });
+    });
+
+    describe("parseTag", () => {
+      it("should parse alphanumeric ids as strings", () => {
+        expect(parseTag('<PII type="PERSON" id="a4f2c9"/>')).toEqual({
+          type: PIIType.PERSON,
+          id: "a4f2c9",
+          semantic: undefined,
+        });
+      });
+
+      it("should keep decimal-only ids as numbers", () => {
+        expect(parseTag('<PII type="PERSON" id="42"/>')?.id).toBe(42);
+      });
+
+      it("should reject uppercase, separators and empty ids", () => {
+        expect(parseTag('<PII type="PERSON" id="A4F2C9"/>')).toBeNull();
+        expect(parseTag('<PII type="PERSON" id="a4-f2"/>')).toBeNull();
+        expect(parseTag('<PII type="PERSON" id="a4_f2"/>')).toBeNull();
+        expect(parseTag('<PII type="PERSON" id=""/>')).toBeNull();
+      });
+
+      it("should parse alphanumeric ids with semantic attributes", () => {
+        expect(
+          parseTag('<PII type="PERSON" gender="female" id="x1y2z3"/>')
+        ).toEqual({
+          type: PIIType.PERSON,
+          id: "x1y2z3",
+          semantic: { gender: "female" },
+        });
+      });
+    });
+
+    describe("extractTags (fuzzy)", () => {
+      it("should extract alphanumeric ids", () => {
+        const tags = extractTags('Hi <PII type="PERSON" id="a4f2c9"/>');
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.id).toBe("a4f2c9");
+      });
+
+      it("should fold a case-mangled id back to lowercase", () => {
+        const tags = extractTags('Hi <pii Type="person" Id="A4F2C9" />');
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.type).toBe(PIIType.PERSON);
+        expect(tags[0]?.id).toBe("a4f2c9");
+      });
+
+      it("should handle alphanumeric ids with attribute reordering", () => {
+        const tags = extractTags('<PII id="a4f2c9" type="PERSON"/>');
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.id).toBe("a4f2c9");
+      });
+
+      it("should handle alphanumeric ids with a leaked close delimiter", () => {
+        const tags = extractTags('<PII type="PERSON" id="a4f2c9/>"');
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.id).toBe("a4f2c9");
+      });
+
+      it("should handle alphanumeric ids with HTML-encoded brackets", () => {
+        const tags = extractTags('&lt;PII type="PERSON" id="a4f2c9"/&gt;');
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.id).toBe("a4f2c9");
+      });
+
+      it("should keep decimal-only ids numeric", () => {
+        expect(extractTags('<PII type="PERSON" id="12"/>')[0]?.id).toBe(12);
+      });
+    });
+
+    describe("extractTagsStrict", () => {
+      it("should extract alphanumeric ids", () => {
+        const tags = extractTagsStrict('<PII type="PERSON" id="a4f2c9"/>');
+        expect(tags).toHaveLength(1);
+        expect(tags[0]?.id).toBe("a4f2c9");
+      });
+
+      it("should not match uppercase ids", () => {
+        expect(extractTagsStrict('<PII type="PERSON" id="A4F2C9"/>')).toEqual([]);
+      });
+    });
+
+    describe("rehydrate", () => {
+      it("should rehydrate alphanumeric ids", () => {
+        const piiMap: RawPIIMap = new Map([["PERSON_a4f2c9", "Alice"]]);
+        expect(rehydrate('Hi <PII type="PERSON" id="a4f2c9"/>', piiMap)).toBe(
+          "Hi Alice"
+        );
+        expect(
+          rehydrate('Hi <PII type="PERSON" id="a4f2c9"/>', piiMap, true)
+        ).toBe("Hi Alice");
+      });
+
+      it("should rehydrate a case-mangled alphanumeric id", () => {
+        const piiMap: RawPIIMap = new Map([["PERSON_a4f2c9", "Alice"]]);
+        expect(rehydrate('Hi <PII type="PERSON" id="A4F2C9"/>', piiMap)).toBe(
+          "Hi Alice"
+        );
+      });
+
+      it("should leave an unknown alphanumeric id as a visible tag", () => {
+        const piiMap: RawPIIMap = new Map([["PERSON_a4f2c9", "Alice"]]);
+        const text = 'Hi <PII type="PERSON" id="deadbeef"/>';
+        expect(rehydrate(text, piiMap)).toBe(text);
+      });
+
+      it("should rehydrate mixed numeric and alphanumeric ids", () => {
+        const piiMap: RawPIIMap = new Map([
+          ["PERSON_1", "Alice"],
+          ["EMAIL_k9m2p", "alice@acme.com"],
+        ]);
+        expect(
+          rehydrate(
+            '<PII type="PERSON" id="1"/> <<PII type="EMAIL" id="k9m2p"/>>',
+            piiMap
+          )
+        ).toBe("Alice <alice@acme.com>");
+      });
+    });
+
+    describe("tagEntities with alphanumeric ids in existingPiiMap", () => {
+      it("should reuse an alphanumeric id for a known value", () => {
+        const existing: RawPIIMap = new Map([["PERSON_a4f2c9", "Alice"]]);
+        const result = tagEntities(
+          "Hi Alice",
+          [span(PIIType.PERSON, "Alice", 3)],
+          defaultPolicy,
+          existing
+        );
+        expect(result.anonymizedText).toBe('Hi <PII type="PERSON" id="a4f2c9"/>');
+        expect(result.entities[0]?.id).toBe("a4f2c9");
+        expect(result.piiMap.get("PERSON_a4f2c9")).toBe("Alice");
+      });
+
+      it("should compute maxId from numeric ids only", () => {
+        const existing: RawPIIMap = new Map([
+          ["PERSON_a4f2c9", "Alice"],
+          ["PERSON_2", "Bob"],
+          ["EMAIL_zzzzzzzz", "bob@acme.com"],
+        ]);
+        const result = tagEntities(
+          "Hi Carol",
+          [span(PIIType.PERSON, "Carol", 3)],
+          defaultPolicy,
+          existing
+        );
+        // Alphanumeric ids must not influence the counter: next is 2 + 1.
+        expect(result.anonymizedText).toBe('Hi <PII type="PERSON" id="3"/>');
+        expect(result.entities[0]?.id).toBe(3);
+      });
+
+      it("should start at 1 when the existing map has only alphanumeric ids", () => {
+        const existing: RawPIIMap = new Map([["PERSON_a4f2c9", "Alice"]]);
+        const result = tagEntities(
+          "Hi Carol",
+          [span(PIIType.PERSON, "Carol", 3)],
+          defaultPolicy,
+          existing
+        );
+        expect(result.anonymizedText).toBe('Hi <PII type="PERSON" id="1"/>');
+      });
+
+      it("should reuse an alphanumeric id for repeated occurrences in one call", () => {
+        const existing: RawPIIMap = new Map([["PERSON_a4f2c9", "Alice"]]);
+        const result = tagEntities(
+          "Alice and Alice",
+          [span(PIIType.PERSON, "Alice", 0), span(PIIType.PERSON, "Alice", 10)],
+          { ...defaultPolicy, reuseIdsForRepeatedPII: false },
+          existing
+        );
+        expect(result.anonymizedText).toBe(
+          '<PII type="PERSON" id="a4f2c9"/> and <PII type="PERSON" id="a4f2c9"/>'
+        );
+      });
+
+      it("should ignore existing keys with invalid ids", () => {
+        const existing: RawPIIMap = new Map([
+          ["PERSON_A4F2C9", "Alice"],
+          ["PERSON_a4-f2", "Alice"],
+        ]);
+        const result = tagEntities(
+          "Hi Alice",
+          [span(PIIType.PERSON, "Alice", 3)],
+          defaultPolicy,
+          existing
+        );
+        expect(result.anonymizedText).toBe('Hi <PII type="PERSON" id="1"/>');
+      });
+
+      it("should round-trip an alphanumeric id through tagEntities and rehydrate", () => {
+        const existing: RawPIIMap = new Map([["PERSON_a4f2c9", "Alice"]]);
+        const result = tagEntities(
+          "Hi Alice",
+          [span(PIIType.PERSON, "Alice", 3)],
+          defaultPolicy,
+          existing
+        );
+        expect(rehydrate(result.anonymizedText, result.piiMap)).toBe("Hi Alice");
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- widen PII tag IDs to lowercase alphanumeric values while preserving numeric IDs as numbers
- reuse externally seeded string IDs throughout tagging, validation, CLI output, and rehydration
- keep the numeric counter based only on numeric IDs from an existing PII map
- document safe construction constraints for stable external IDs

## Compatibility

Existing decimal-only IDs continue to parse and surface as numbers. Fuzzy extraction lowercases case-mangled alphanumeric IDs, while strict extraction accepts only the canonical lowercase form.

## Testing

- `npm exec -- tsc --noEmit`
- `npm exec -- eslint src/types/index.ts src/pipeline/tagger.ts src/pipeline/validator.ts src/cli/commands/anonymize.ts`
- `npm exec -- vitest run test/pipeline/tagger.test.ts test/integration/anonymizer.test.ts test/pipeline/validator.test.ts test/integration/browser-entry.test.ts test/cli/commands/anonymize.test.ts test/types/index.test.ts` (343 tests)

Closes #91
