### PR TITLE
feat(opencode): redact VCS identities

### DIFF
--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -42,15 +42,16 @@ export default createRehydraPlugin({
   // Disable detection of specific PII types
   disableTypes: ["URL", "IP_ADDRESS"],
 
-  // Redact participant logins in gh pr and gh api output
-  githubIdentities: true,
+  // Redact identities in Git and GitHub CLI output
+  vcsIdentities: true,
 });
 ```
 
-`githubIdentities` detects logins in GitHub CLI author, assignee, reviewer, and
-JSON `login` fields, then redacts every occurrence of those logins in that tool
-output. It does not redact npm scopes or other `@` identifiers in unrelated
-commands. Display names require the optional local NER model.
+`vcsIdentities` detects logins in `gh pr` and `gh api` output, plus author and
+committer names in `git log`, `git show`, and `git blame` output. It redacts
+every occurrence of those identities in the same tool output without touching
+npm scopes or other `@` identifiers in unrelated commands. GitHub display names
+outside these structured fields still require the optional local NER model.
 
 ## What gets detected
 

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -93,3 +93,5 @@ Full documentation at [docs.rehydra.ai](https://docs.rehydra.ai).
 ## License
 
 MIT
+
+VCS identity discovery supports direct `gh pr`, `gh api`, `git log`, `git show`, and `git blame` commands, including global options such as `git -C` and `gh --repo`. Commands hidden inside shell scripts or aliases need explicit integration or NER. GitHub discovery masks participant fields and mentions of those participants; it preserves JSON keys and npm scopes. `disableTypes` still takes precedence over identity detection.

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -41,8 +41,16 @@ export default createRehydraPlugin({
 
   // Disable detection of specific PII types
   disableTypes: ["URL", "IP_ADDRESS"],
+
+  // Redact participant logins in gh pr and gh api output
+  githubIdentities: true,
 });
 ```
+
+`githubIdentities` detects logins in GitHub CLI author, assignee, reviewer, and
+JSON `login` fields, then redacts every occurrence of those logins in that tool
+output. It does not redact npm scopes or other `@` identifiers in unrelated
+commands. Display names require the optional local NER model.
 
 ## What gets detected
 

--- a/src/opencode-plugin/git-identity.ts
+++ b/src/opencode-plugin/git-identity.ts
@@ -9,11 +9,11 @@ export const gitIdentityRecognizer: Recognizer = {
   find(text: string): SpanMatch[] {
     const names = new Set<string>();
 
-    for (const match of text.matchAll(/^(?:Author|Commit|Committer):\s*(.+)$/gm)) {
-      names.add(match[1]!.replace(/\s+<[^>]+>\s*$/, "").trim());
+    for (const match of text.matchAll(/^(?:Author|Commit|Committer):[\t ]*(.+)$/gm)) {
+      names.add(match[1]!.replace(/[\t ]+<[^>]*>.*$/, "").trim());
     }
     for (const match of text.matchAll(/^(?:author|committer) (.+)$/gm)) {
-      names.add(match[1]!.trim());
+      names.add(match[1]!.replace(/[\t ]+<[^>]*>.*$/, '').trim());
     }
     for (const match of text.matchAll(/^.*\((.+?)\s+\d{4}-\d{2}-\d{2}\s[^)\n]*\)/gm)) {
       names.add(match[1]!.trim());

--- a/src/opencode-plugin/git-identity.ts
+++ b/src/opencode-plugin/git-identity.ts
@@ -1,0 +1,44 @@
+import { DetectionSource, PIIType, type SpanMatch } from "../types/index.js";
+import type { Recognizer } from "../recognizers/index.js";
+
+export const gitIdentityRecognizer: Recognizer = {
+  type: PIIType.PERSON,
+  name: "GitIdentityRecognizer",
+  defaultConfidence: 1,
+
+  find(text: string): SpanMatch[] {
+    const names = new Set<string>();
+
+    for (const match of text.matchAll(/^(?:Author|Commit|Committer):\s*(.+)$/gm)) {
+      names.add(match[1]!.replace(/\s+<[^>]+>\s*$/, "").trim());
+    }
+    for (const match of text.matchAll(/^(?:author|committer) (.+)$/gm)) {
+      names.add(match[1]!.trim());
+    }
+    for (const match of text.matchAll(/^.*\((.+?)\s+\d{4}-\d{2}-\d{2}\s[^)\n]*\)/gm)) {
+      names.add(match[1]!.trim());
+    }
+
+    const matches: SpanMatch[] = [];
+    for (const name of names) {
+      if (name === "") continue;
+      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const pattern = new RegExp(
+        `(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`,
+        "giu",
+      );
+      for (const match of text.matchAll(pattern)) {
+        matches.push({
+          type: PIIType.PERSON,
+          start: match.index,
+          end: match.index + match[0].length,
+          confidence: 1,
+          source: DetectionSource.REGEX,
+          text: match[0],
+        });
+      }
+    }
+
+    return matches;
+  },
+};

--- a/src/opencode-plugin/github-username.ts
+++ b/src/opencode-plugin/github-username.ts
@@ -10,45 +10,35 @@ export const githubUsernameRecognizer: Recognizer = {
 
   find(text: string): SpanMatch[] {
     const logins = new Set<string>();
-
-    const jsonLoginPattern = new RegExp(
-      String.raw`"login"\s*:\s*"(${LOGIN})"`,
-      "g",
-    );
-    for (const match of text.matchAll(jsonLoginPattern)) {
-      logins.add(match[1]!);
+    const matches = new Map<number, SpanMatch>();
+    function add(start: number, login: string): void {
+      logins.add(login);
+      matches.set(start, {
+        type: PIIType.GITHUB_USERNAME, start, end: start + login.length,
+        confidence: 1, source: DetectionSource.REGEX, text: login,
+      });
     }
-
-    const summaryLoginPattern = new RegExp(
-      String.raw`^(?:author|assignees|reviewers):\s*(.+)$`,
-      "gm",
-    );
-    for (const match of text.matchAll(summaryLoginPattern)) {
-      for (const value of match[1]!.split(",")) {
-        const login = value.trim().match(new RegExp(`^(${LOGIN})`))?.[1];
-        if (login !== undefined) logins.add(login);
+    // Restrict JSON matches to values, so a login like "id" cannot mask JSON keys.
+    for (const match of text.matchAll(new RegExp(String.raw`"login"\s*:\s*"(${LOGIN})"`, 'g'))) {
+      add(match.index + match[0].lastIndexOf(match[1]!), match[1]!);
+    }
+    for (const match of text.matchAll(/^(?:author|assignees|reviewers):[\t ]*(.+)$/gim)) {
+      const list = match[1]!;
+      const offset = match.index + match[0].indexOf(list);
+      const entry = new RegExp(String.raw`(?:^|,)[\t ]*(${LOGIN})(?=[\t ,(]|$)`, 'g');
+      for (const item of list.matchAll(entry)) {
+        add(offset + item.index + item[0].lastIndexOf(item[1]!), item[1]!);
       }
     }
-
-    const matches: SpanMatch[] = [];
+    // Cover mentions of discovered participants, but preserve npm scopes.
     for (const login of logins) {
-      const escaped = login.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const pattern = new RegExp(
-        `(?<![A-Za-z0-9-])${escaped}(?![A-Za-z0-9-])`,
-        "gi",
-      );
-      for (const match of text.matchAll(pattern)) {
-        matches.push({
-          type: PIIType.GITHUB_USERNAME,
-          start: match.index,
-          end: match.index + match[0].length,
-          confidence: 1,
-          source: DetectionSource.REGEX,
-          text: match[0],
-        });
+      const escaped = login.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      for (const match of text.matchAll(new RegExp(`(?<![A-Za-z0-9_/@])@(${escaped})(?![A-Za-z0-9-/])`, 'gi'))) {
+        const value = match[1]!;
+        matches.set(match.index + 1, { type: PIIType.GITHUB_USERNAME, start: match.index + 1,
+          end: match.index + 1 + value.length, confidence: 1, source: DetectionSource.REGEX, text: value });
       }
     }
-
-    return matches;
+    return [...matches.values()];
   },
 };

--- a/src/opencode-plugin/github-username.ts
+++ b/src/opencode-plugin/github-username.ts
@@ -1,0 +1,54 @@
+import { DetectionSource, PIIType, type SpanMatch } from "../types/index.js";
+import type { Recognizer } from "../recognizers/index.js";
+
+const LOGIN = String.raw`[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?:\[bot\])?`;
+
+export const githubUsernameRecognizer: Recognizer = {
+  type: PIIType.GITHUB_USERNAME,
+  name: "GitHubUsernameRecognizer",
+  defaultConfidence: 1,
+
+  find(text: string): SpanMatch[] {
+    const logins = new Set<string>();
+
+    const jsonLoginPattern = new RegExp(
+      String.raw`"login"\s*:\s*"(${LOGIN})"`,
+      "g",
+    );
+    for (const match of text.matchAll(jsonLoginPattern)) {
+      logins.add(match[1]!);
+    }
+
+    const summaryLoginPattern = new RegExp(
+      String.raw`^(?:author|assignees|reviewers):\s*(.+)$`,
+      "gm",
+    );
+    for (const match of text.matchAll(summaryLoginPattern)) {
+      for (const value of match[1]!.split(",")) {
+        const login = value.trim().match(new RegExp(`^(${LOGIN})`))?.[1];
+        if (login !== undefined) logins.add(login);
+      }
+    }
+
+    const matches: SpanMatch[] = [];
+    for (const login of logins) {
+      const escaped = login.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const pattern = new RegExp(
+        `(?<![A-Za-z0-9-])${escaped}(?![A-Za-z0-9-])`,
+        "gi",
+      );
+      for (const match of text.matchAll(pattern)) {
+        matches.push({
+          type: PIIType.GITHUB_USERNAME,
+          start: match.index,
+          end: match.index + match[0].length,
+          confidence: 1,
+          source: DetectionSource.REGEX,
+          text: match[0],
+        });
+      }
+    }
+
+    return matches;
+  },
+};

--- a/src/opencode-plugin/identity-recognizer.ts
+++ b/src/opencode-plugin/identity-recognizer.ts
@@ -1,0 +1,24 @@
+import type { Recognizer } from '../recognizers/base.js';
+import { extractTagsStrict } from '../pipeline/tagger.js';
+import type { TagFormat } from '../types/index.js';
+
+/** Keep repeated history transforms from discovering an existing tag as a name. */
+export function protectIdentityTags(recognizer: Recognizer, format: TagFormat): Recognizer {
+  return {
+    ...recognizer,
+    find(text): ReturnType<Recognizer['find']> {
+      const tags = extractTagsStrict(text, format);
+      if (tags.length === 0) return recognizer.find(text);
+      const pieces: string[] = [];
+      let offset = 0;
+      for (const tag of tags) {
+        pieces.push(text.slice(offset, tag.position), ' '.repeat(tag.matchedText.length));
+        offset = tag.position + tag.matchedText.length;
+      }
+      pieces.push(text.slice(offset));
+      return recognizer.find(pieces.join('')).filter(match =>
+        !tags.some(tag => match.start < tag.position + tag.matchedText.length && match.end > tag.position),
+      );
+    },
+  };
+}

--- a/src/opencode-plugin/plugin.ts
+++ b/src/opencode-plugin/plugin.ts
@@ -20,6 +20,7 @@ import type { AnonymizationPolicy } from "../types/index.js";
 import type { PIITypeName, RehydraPluginOptions } from "./types.js";
 import { buildPIISystemInstruction } from "../proxy/system-instruction.js";
 import { buildTagPrefix } from "../utils/regex.js";
+import { githubUsernameRecognizer } from "./github-username.js";
 
 /**
  * OpenCode Plugin types — matches signatures from @opencode-ai/plugin.
@@ -140,6 +141,9 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
       keyProvider,
       piiStorageProvider: piiStorage,
     });
+    if (options?.githubIdentities === true) {
+      anonymizer.getRegistry().register(githubUsernameRecognizer);
+    }
     await anonymizer.initialize();
 
     // Build policy with disabled types (URL and IP_ADDRESS disabled by default)
@@ -177,6 +181,25 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
     });
 
     const locale = options?.locale;
+    const githubPolicy: Partial<AnonymizationPolicy> | undefined =
+      options?.githubIdentities === true
+        ? {
+            ...policy,
+            enabledTypes: new Set([
+              ...(policy?.enabledTypes ?? [
+                ...createDefaultPolicy().enabledTypes,
+                ...SECRET_PII_TYPES,
+              ]),
+              PIIType.GITHUB_USERNAME,
+            ]),
+            regexEnabledTypes: new Set([
+              ...(policy?.regexEnabledTypes ??
+                createDefaultPolicy().regexEnabledTypes),
+              PIIType.GITHUB_USERNAME,
+            ]),
+            reuseIdsForRepeatedPII: true,
+          }
+        : undefined;
 
     // One session per OpenCode session, keyed by sessionID
     const sessions = new Map<string, AnonymizerSessionImpl>();
@@ -241,10 +264,19 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
               part.state.status === "completed" &&
               typeof part.state.output === "string"
             ) {
+              const command = (
+                part.state as { input?: { command?: unknown } }
+              ).input?.command;
+              const outputPolicy =
+                githubPolicy !== undefined &&
+                typeof command === "string" &&
+                /\bgh\s+(?:pr|api)\b/.test(command)
+                  ? githubPolicy
+                  : policy;
               const result = await session.anonymize(
                 part.state.output,
                 locale,
-                policy,
+                outputPolicy,
               );
               if (result.stats.totalEntities > 0) {
                 hasAnonymized = true;

--- a/src/opencode-plugin/plugin.ts
+++ b/src/opencode-plugin/plugin.ts
@@ -21,6 +21,7 @@ import type { PIITypeName, RehydraPluginOptions } from "./types.js";
 import { buildPIISystemInstruction } from "../proxy/system-instruction.js";
 import { buildTagPrefix } from "../utils/regex.js";
 import { githubUsernameRecognizer } from "./github-username.js";
+import { protectIdentityTags } from "./identity-recognizer.js";
 import { vcsCommandTypes } from "./vcs-command.js";
 import { gitIdentityRecognizer } from "./git-identity.js";
 
@@ -144,8 +145,8 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
       piiStorageProvider: piiStorage,
     });
     if (options?.vcsIdentities === true) {
-      anonymizer.getRegistry().register(githubUsernameRecognizer);
-      anonymizer.getRegistry().register(gitIdentityRecognizer);
+      anonymizer.getRegistry().register(protectIdentityTags(githubUsernameRecognizer, tagFormat));
+      anonymizer.getRegistry().register(protectIdentityTags(gitIdentityRecognizer, tagFormat));
     }
     await anonymizer.initialize();
 

--- a/src/opencode-plugin/plugin.ts
+++ b/src/opencode-plugin/plugin.ts
@@ -21,6 +21,7 @@ import type { PIITypeName, RehydraPluginOptions } from "./types.js";
 import { buildPIISystemInstruction } from "../proxy/system-instruction.js";
 import { buildTagPrefix } from "../utils/regex.js";
 import { githubUsernameRecognizer } from "./github-username.js";
+import { vcsCommandTypes } from "./vcs-command.js";
 import { gitIdentityRecognizer } from "./git-identity.js";
 
 /**
@@ -183,26 +184,21 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
     });
 
     const locale = options?.locale;
-    const identityPolicy = (
-      type: PIIType,
-    ): Partial<AnonymizationPolicy> => ({
-      ...policy,
-      enabledTypes: new Set([
-        ...(policy?.enabledTypes ?? [
-          ...createDefaultPolicy().enabledTypes,
-          ...SECRET_PII_TYPES,
-        ]),
-        type,
-      ]),
-      regexEnabledTypes: new Set([
-        ...(policy?.regexEnabledTypes ??
-          createDefaultPolicy().regexEnabledTypes),
-        type,
-      ]),
-      reuseIdsForRepeatedPII: true,
-    });
-    const githubPolicy = identityPolicy(PIIType.GITHUB_USERNAME);
-    const gitPolicy = identityPolicy(PIIType.PERSON);
+    const identityPolicy = (types: PIIType[]): Partial<AnonymizationPolicy> => {
+      const defaults = createDefaultPolicy();
+      const configPolicy = anonymizerConfig.defaultPolicy;
+      const enabledTypes = new Set(policy?.enabledTypes ?? configPolicy?.enabledTypes ?? defaults.enabledTypes);
+      const regexEnabledTypes = new Set(policy?.regexEnabledTypes ?? configPolicy?.regexEnabledTypes ?? defaults.regexEnabledTypes);
+      if (anonymizerConfig.secrets?.enabled === true) {
+        for (const type of SECRET_PII_TYPES) {
+          if (!disableTypes.includes(type)) { enabledTypes.add(type); regexEnabledTypes.add(type); }
+        }
+      }
+      for (const type of types) {
+        if (!disableTypes.includes(type)) { enabledTypes.add(type); regexEnabledTypes.add(type); }
+      }
+      return { ...policy, enabledTypes, regexEnabledTypes, reuseIdsForRepeatedPII: true };
+    };
 
     // One session per OpenCode session, keyed by sessionID
     const sessions = new Map<string, AnonymizerSessionImpl>();
@@ -275,11 +271,11 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
                 options?.vcsIdentities === true &&
                 typeof command === "string"
               ) {
-                if (/\bgh\s+(?:pr|api)\b/.test(command)) {
-                  outputPolicy = githubPolicy;
-                } else if (/\bgit\s+(?:log|show|blame)\b/.test(command)) {
-                  outputPolicy = gitPolicy;
-                }
+                const commands = vcsCommandTypes(command);
+                const types: PIIType[] = [];
+                if (commands.has('github')) types.push(PIIType.GITHUB_USERNAME);
+                if (commands.has('git')) types.push(PIIType.PERSON);
+                if (types.length > 0) outputPolicy = identityPolicy(types);
               }
               const result = await session.anonymize(
                 part.state.output,

--- a/src/opencode-plugin/plugin.ts
+++ b/src/opencode-plugin/plugin.ts
@@ -21,6 +21,7 @@ import type { PIITypeName, RehydraPluginOptions } from "./types.js";
 import { buildPIISystemInstruction } from "../proxy/system-instruction.js";
 import { buildTagPrefix } from "../utils/regex.js";
 import { githubUsernameRecognizer } from "./github-username.js";
+import { gitIdentityRecognizer } from "./git-identity.js";
 
 /**
  * OpenCode Plugin types — matches signatures from @opencode-ai/plugin.
@@ -141,8 +142,9 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
       keyProvider,
       piiStorageProvider: piiStorage,
     });
-    if (options?.githubIdentities === true) {
+    if (options?.vcsIdentities === true) {
       anonymizer.getRegistry().register(githubUsernameRecognizer);
+      anonymizer.getRegistry().register(gitIdentityRecognizer);
     }
     await anonymizer.initialize();
 
@@ -181,25 +183,26 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
     });
 
     const locale = options?.locale;
-    const githubPolicy: Partial<AnonymizationPolicy> | undefined =
-      options?.githubIdentities === true
-        ? {
-            ...policy,
-            enabledTypes: new Set([
-              ...(policy?.enabledTypes ?? [
-                ...createDefaultPolicy().enabledTypes,
-                ...SECRET_PII_TYPES,
-              ]),
-              PIIType.GITHUB_USERNAME,
-            ]),
-            regexEnabledTypes: new Set([
-              ...(policy?.regexEnabledTypes ??
-                createDefaultPolicy().regexEnabledTypes),
-              PIIType.GITHUB_USERNAME,
-            ]),
-            reuseIdsForRepeatedPII: true,
-          }
-        : undefined;
+    const identityPolicy = (
+      type: PIIType,
+    ): Partial<AnonymizationPolicy> => ({
+      ...policy,
+      enabledTypes: new Set([
+        ...(policy?.enabledTypes ?? [
+          ...createDefaultPolicy().enabledTypes,
+          ...SECRET_PII_TYPES,
+        ]),
+        type,
+      ]),
+      regexEnabledTypes: new Set([
+        ...(policy?.regexEnabledTypes ??
+          createDefaultPolicy().regexEnabledTypes),
+        type,
+      ]),
+      reuseIdsForRepeatedPII: true,
+    });
+    const githubPolicy = identityPolicy(PIIType.GITHUB_USERNAME);
+    const gitPolicy = identityPolicy(PIIType.PERSON);
 
     // One session per OpenCode session, keyed by sessionID
     const sessions = new Map<string, AnonymizerSessionImpl>();
@@ -267,12 +270,17 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
               const command = (
                 part.state as { input?: { command?: unknown } }
               ).input?.command;
-              const outputPolicy =
-                githubPolicy !== undefined &&
-                typeof command === "string" &&
-                /\bgh\s+(?:pr|api)\b/.test(command)
-                  ? githubPolicy
-                  : policy;
+              let outputPolicy = policy;
+              if (
+                options?.vcsIdentities === true &&
+                typeof command === "string"
+              ) {
+                if (/\bgh\s+(?:pr|api)\b/.test(command)) {
+                  outputPolicy = githubPolicy;
+                } else if (/\bgit\s+(?:log|show|blame)\b/.test(command)) {
+                  outputPolicy = gitPolicy;
+                }
+              }
               const result = await session.anonymize(
                 part.state.output,
                 locale,

--- a/src/opencode-plugin/types.ts
+++ b/src/opencode-plugin/types.ts
@@ -28,8 +28,8 @@ export interface RehydraPluginOptions {
   /** Locale hint for anonymization */
   locale?: string;
 
-  /** Redact participant logins found in GitHub CLI pull request output */
-  githubIdentities?: boolean;
+  /** Redact identities found in Git and GitHub CLI output */
+  vcsIdentities?: boolean;
 
   /** Policy overrides */
   policy?: Partial<AnonymizationPolicy>;

--- a/src/opencode-plugin/types.ts
+++ b/src/opencode-plugin/types.ts
@@ -28,6 +28,9 @@ export interface RehydraPluginOptions {
   /** Locale hint for anonymization */
   locale?: string;
 
+  /** Redact participant logins found in GitHub CLI pull request output */
+  githubIdentities?: boolean;
+
   /** Policy overrides */
   policy?: Partial<AnonymizationPolicy>;
 

--- a/src/opencode-plugin/vcs-command.ts
+++ b/src/opencode-plugin/vcs-command.ts
@@ -1,0 +1,24 @@
+/** Recognize direct Git/GitHub commands without matching quoted prose or arguments. */
+export function vcsCommandTypes(command: string): Set<'git' | 'github'> {
+  const tokens = command.match(/"(?:\\.|[^"\\])*"|'[^']*'|[\n;&|]+|[^\s;&|]+/g) ?? [];
+  const result = new Set<'git' | 'github'>();
+  let start = true;
+  for (let i = 0; i < tokens.length; i++) {
+    const raw = tokens[i]!;
+    if (/^[\n;&|]+$/.test(raw)) { start = true; continue; }
+    if (!start) continue;
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(raw)) continue;
+    start = false;
+    const executable = raw.replace(/^['"]|['"]$/g, '').split('/').pop();
+    if (executable !== 'git' && executable !== 'gh') continue;
+    let j = i + 1;
+    while (tokens[j]?.startsWith('-') === true) {
+      const option = tokens[j++]!;
+      if (['-C', '-c', '--git-dir', '--work-tree', '-R', '--repo', '--hostname'].includes(option)) j++;
+    }
+    const subcommand = tokens[j];
+    if (executable === 'git' && subcommand !== undefined && ['log', 'show', 'blame'].includes(subcommand)) result.add('git');
+    if (executable === 'gh' && subcommand !== undefined && ['pr', 'api'].includes(subcommand)) result.add('github');
+  }
+  return result;
+}

--- a/src/types/pii-types.ts
+++ b/src/types/pii-types.ts
@@ -55,7 +55,6 @@ export const ALL_PII_TYPES: readonly PIIType[] = Object.values(PIIType) as PIITy
 export const REGEX_PII_TYPES: readonly PIIType[] = [
   PIIType.EMAIL,
   PIIType.PHONE,
-  PIIType.GITHUB_USERNAME,
   PIIType.IBAN,
   PIIType.BIC_SWIFT,
   PIIType.CREDIT_CARD,
@@ -67,6 +66,7 @@ export const REGEX_PII_TYPES: readonly PIIType[] = [
   PIIType.DATE,
   PIIType.CASE_ID,
   PIIType.CUSTOMER_ID,
+  PIIType.GITHUB_USERNAME,
 ];
 
 /**
@@ -99,7 +99,6 @@ export const NER_PII_TYPES: readonly PIIType[] = [
  */
 export const DEFAULT_TYPE_PRIORITY: readonly PIIType[] = [
   // Lower priority (generic)
-  PIIType.GITHUB_USERNAME,
   PIIType.URL,
   PIIType.IP_ADDRESS,
   PIIType.LOCATION,

--- a/src/types/pii-types.ts
+++ b/src/types/pii-types.ts
@@ -99,6 +99,7 @@ export const NER_PII_TYPES: readonly PIIType[] = [
  */
 export const DEFAULT_TYPE_PRIORITY: readonly PIIType[] = [
   // Lower priority (generic)
+  PIIType.GITHUB_USERNAME,
   PIIType.URL,
   PIIType.IP_ADDRESS,
   PIIType.LOCATION,

--- a/src/types/pii-types.ts
+++ b/src/types/pii-types.ts
@@ -12,6 +12,7 @@ export enum PIIType {
   // Contact information
   EMAIL = 'EMAIL',
   PHONE = 'PHONE',
+  GITHUB_USERNAME = 'GITHUB_USERNAME',
   URL = 'URL',
   IP_ADDRESS = 'IP_ADDRESS',
 
@@ -54,6 +55,7 @@ export const ALL_PII_TYPES: readonly PIIType[] = Object.values(PIIType) as PIITy
 export const REGEX_PII_TYPES: readonly PIIType[] = [
   PIIType.EMAIL,
   PIIType.PHONE,
+  PIIType.GITHUB_USERNAME,
   PIIType.IBAN,
   PIIType.BIC_SWIFT,
   PIIType.CREDIT_CARD,
@@ -97,6 +99,7 @@ export const NER_PII_TYPES: readonly PIIType[] = [
  */
 export const DEFAULT_TYPE_PRIORITY: readonly PIIType[] = [
   // Lower priority (generic)
+  PIIType.GITHUB_USERNAME,
   PIIType.URL,
   PIIType.IP_ADDRESS,
   PIIType.LOCATION,
@@ -157,4 +160,3 @@ export function getPIITypeFromNERLabel(label: string): PIIType | null {
 
   return NER_LABEL_TO_PII_TYPE[cleanLabel] ?? null;
 }
-

--- a/test/opencode-plugin/plugin.test.ts
+++ b/test/opencode-plugin/plugin.test.ts
@@ -32,6 +32,7 @@ function toolPart(
   output: string,
   sessionID = "ses-1",
   messageID = "msg-1",
+  command = "echo test",
 ): Record<string, unknown> {
   return {
     id: `part-${Math.random().toString(36).slice(2, 8)}`,
@@ -42,7 +43,7 @@ function toolPart(
     tool: "bash",
     state: {
       status: "completed",
-      input: { command: "echo test" },
+      input: { command },
       output,
       title: "bash",
       metadata: {},
@@ -209,6 +210,74 @@ describe("OpenCode Plugin", () => {
 
       const text = (output.messages[0]!.parts[0] as { text: string }).text;
       expect(text).toBe(originalText);
+    });
+
+    it("should anonymize GitHub participants only in gh output when enabled", async () => {
+      const githubPlugin = createRehydraPlugin({ githubIdentities: true });
+      const githubHooks = (await githubPlugin(mockCtx())) as Record<
+        string,
+        (...args: any[]) => Promise<void>
+      >;
+      const output = {
+        messages: [
+          message(
+            "assistant",
+            [
+              toolPart(
+                "author:\talice-dev\nreviewers:\toctocat (Approved)\n{\"author\":{\"login\":\"json-user\"}}\n--\n@alice-dev asked @octocat and @json-user to check @rehydra/opencode",
+                "ses-github",
+                "msg-github",
+                "gh pr view 42 --comments",
+              ),
+            ],
+            "ses-github",
+          ),
+        ],
+      };
+
+      await githubHooks["experimental.chat.messages.transform"]!({}, output);
+
+      const state = (
+        output.messages[0]!.parts[0] as { state: { output: string } }
+      ).state;
+      expect(state.output).not.toContain("alice-dev");
+      expect(state.output).not.toContain("octocat");
+      expect(state.output).not.toContain("json-user");
+      expect(state.output).toContain("@rehydra/opencode");
+      expect(state.output.match(/GITHUB_USERNAME/g)).toHaveLength(6);
+
+      const args = {
+        args: { command: `gh pr comment 42 --body '${state.output}'` },
+      };
+      await githubHooks["tool.execute.before"]!(
+        { tool: "bash", sessionID: "ses-github", callID: "call-github" },
+        args,
+      );
+      expect(args.args.command).toContain("@alice-dev");
+      expect(args.args.command).toContain("@octocat");
+      expect(args.args.command).toContain("@json-user");
+    });
+
+    it("should leave GitHub-like names in unrelated tool output", async () => {
+      const githubPlugin = createRehydraPlugin({ githubIdentities: true });
+      const githubHooks = (await githubPlugin(mockCtx())) as Record<
+        string,
+        (...args: any[]) => Promise<void>
+      >;
+      const output = {
+        messages: [
+          message("assistant", [
+            toolPart("author:\talice-dev\n@alice-dev"),
+          ]),
+        ],
+      };
+
+      await githubHooks["experimental.chat.messages.transform"]!({}, output);
+
+      const state = (
+        output.messages[0]!.parts[0] as { state: { output: string } }
+      ).state;
+      expect(state.output).toContain("alice-dev");
     });
   });
 

--- a/test/opencode-plugin/plugin.test.ts
+++ b/test/opencode-plugin/plugin.test.ts
@@ -213,7 +213,7 @@ describe("OpenCode Plugin", () => {
     });
 
     it("should anonymize GitHub participants only in gh output when enabled", async () => {
-      const githubPlugin = createRehydraPlugin({ githubIdentities: true });
+      const githubPlugin = createRehydraPlugin({ vcsIdentities: true });
       const githubHooks = (await githubPlugin(mockCtx())) as Record<
         string,
         (...args: any[]) => Promise<void>
@@ -259,7 +259,7 @@ describe("OpenCode Plugin", () => {
     });
 
     it("should leave GitHub-like names in unrelated tool output", async () => {
-      const githubPlugin = createRehydraPlugin({ githubIdentities: true });
+      const githubPlugin = createRehydraPlugin({ vcsIdentities: true });
       const githubHooks = (await githubPlugin(mockCtx())) as Record<
         string,
         (...args: any[]) => Promise<void>
@@ -278,6 +278,52 @@ describe("OpenCode Plugin", () => {
         output.messages[0]!.parts[0] as { state: { output: string } }
       ).state;
       expect(state.output).toContain("alice-dev");
+    });
+
+    it("should anonymize identities in git output when enabled", async () => {
+      const vcsPlugin = createRehydraPlugin({ vcsIdentities: true });
+      const vcsHooks = (await vcsPlugin(mockCtx())) as Record<
+        string,
+        (...args: any[]) => Promise<void>
+      >;
+      const output = {
+        messages: [
+          message(
+            "assistant",
+            [
+              toolPart(
+                "commit abc123\nAuthor: Alice Developer <alice@example.com>\nauthor Bob Builder\nabc123 (Carol Coder 2026-09-03 10:00:00 +0000 1) line\n\n    Pair with Alice Developer and Bob Builder\n",
+                "ses-git",
+                "msg-git",
+                "git log -1",
+              ),
+            ],
+            "ses-git",
+          ),
+        ],
+      };
+
+      await vcsHooks["experimental.chat.messages.transform"]!({}, output);
+
+      const state = (
+        output.messages[0]!.parts[0] as { state: { output: string } }
+      ).state;
+      expect(state.output).not.toContain("Alice Developer");
+      expect(state.output).not.toContain("Bob Builder");
+      expect(state.output).not.toContain("Carol Coder");
+      expect(state.output).not.toContain("alice@example.com");
+      expect(state.output.match(/type="PERSON"/g)).toHaveLength(5);
+      expect(state.output).toContain('type="EMAIL"');
+
+      const args = { args: { command: `git show --format='${state.output}'` } };
+      await vcsHooks["tool.execute.before"]!(
+        { tool: "bash", sessionID: "ses-git", callID: "call-git" },
+        args,
+      );
+      expect(args.args.command).toContain("Alice Developer");
+      expect(args.args.command).toContain("Bob Builder");
+      expect(args.args.command).toContain("Carol Coder");
+      expect(args.args.command).toContain("alice@example.com");
     });
   });
 

--- a/test/opencode-plugin/vcs-identities.test.ts
+++ b/test/opencode-plugin/vcs-identities.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { createRehydraPlugin } from '../../src/opencode-plugin/plugin.js';
+import { vcsCommandTypes } from '../../src/opencode-plugin/vcs-command.js';
+import { githubUsernameRecognizer } from '../../src/opencode-plugin/github-username.js';
+import { gitIdentityRecognizer } from '../../src/opencode-plugin/git-identity.js';
+import type { RehydraPluginOptions } from '../../src/opencode-plugin/types.js';
+
+async function scrub(command: string, text: string, options: RehydraPluginOptions = {}) {
+  const hooks = await createRehydraPlugin({ vcsIdentities: true, ...options })({ directory: '/test', worktree: '/test', client: { app: { log: async () => {} } } });
+  const part = { type: 'tool', state: { status: 'completed', input: { command }, output: text } };
+  const output = { messages: [{ info: { sessionID: 'vcs-test', role: 'assistant' }, parts: [part] }] };
+  await hooks['experimental.chat.messages.transform']!({}, output);
+  return { text: part.state.output, hooks };
+}
+
+describe('VCS command context', () => {
+  it.each(['git -C "/tmp/my repo" log -1', 'git --no-pager show', 'GIT_PAGER=cat git blame file', '/usr/bin/git --git-dir=.git log'])('recognizes %s', (cmd) => {
+    expect(vcsCommandTypes(cmd)).toEqual(new Set(['git']));
+  });
+  it.each(['gh --repo org/repo pr view', 'gh -R org/repo api repos/org/repo/pulls'])('recognizes %s', (cmd) => {
+    expect(vcsCommandTypes(cmd)).toEqual(new Set(['github']));
+  });
+  it.each(['echo "git log"', "printf 'gh pr view'", 'cat log.txt', "node -e 'git show'", 'git status'])('does not infer VCS context from %s', (cmd) => {
+    expect(vcsCommandTypes(cmd).size).toBe(0);
+  });
+  it('recognizes separate commands', () => {
+    expect(vcsCommandTypes('git log\ngh pr view')).toEqual(new Set(['git', 'github']));
+  });
+});
+
+it('does not replace JSON keys or npm scopes that equal a known login', () => {
+  const text = '{"id":1,"login":"id"}\n@id asked about @id/package';
+  const spans = githubUsernameRecognizer.find(text);
+  expect(spans.map(s => text.slice(s.start, s.end))).toEqual(['id', 'id']);
+  expect(spans[0]!.start).toBe(text.indexOf('"id"', 10) + 1);
+  expect(spans[1]!.start).toBe(text.indexOf('@id') + 1);
+});
+
+it('extracts names from raw git headers without swallowing email or timestamp', () => {
+  const text = 'author Zoë Example <zoe@example.com> 1720000000 +0000\ncommitter Other Name <other@example.com> 1720000000 +0000';
+  expect(gitIdentityRecognizer.find(text).map(s => s.text)).toEqual(['Zoë Example', 'Other Name']);
+});
+
+it('honors disabled identity types', async () => {
+  const input = 'author:\talice-dev\nAuthor: Alice Developer <alice@example.com>';
+  const result = await scrub('gh pr view; git log', input, { disableTypes: ['PERSON', 'GITHUB_USERNAME'] });
+  expect(result.text).toContain('alice-dev');
+  expect(result.text).toContain('Alice Developer');
+  expect(result.text).not.toContain('alice@example.com');
+});
+
+it('preserves secret detection when the default disabled-types list is cleared', async () => {
+  const result = await scrub('gh pr view', 'author:\talice-dev\nsecret-value-here', { disableTypes: [], redactValues: ['secret-value-here'] });
+  expect(result.text).not.toContain('secret-value-here');
+  expect(result.text).not.toContain('alice-dev');
+});
+
+it('keeps identities stable across history transforms and restores tool arguments', async () => {
+  const input = 'Author: Zoë Example <zoe@example.com>';
+  const { text, hooks } = await scrub('git -C /tmp/repo log', input);
+  const part = { type: 'tool', state: { status: 'completed', input: { command: 'git show' }, output: input } };
+  const output = { messages: [{ info: { sessionID: 'vcs-test', role: 'assistant' }, parts: [part] }] };
+  await hooks['experimental.chat.messages.transform']!({}, output);
+  expect(part.state.output).toBe(text);
+  const args = { args: { command: text } };
+  await hooks['tool.execute.before']!({ tool: 'bash', sessionID: 'vcs-test', callID: 'call' }, args);
+  expect(args.args.command).toBe(input);
+});

--- a/test/opencode-plugin/vcs-identities.test.ts
+++ b/test/opencode-plugin/vcs-identities.test.ts
@@ -66,3 +66,15 @@ it('keeps identities stable across history transforms and restores tool argument
   await hooks['tool.execute.before']!({ tool: 'bash', sessionID: 'vcs-test', callID: 'call' }, args);
   expect(args.args.command).toBe(input);
 });
+
+it.each([undefined, { open: '[[', close: ']]', keyword: 'PRIVATE' }])('does not anonymize an existing identity tag again: %j', async (tagFormat) => {
+  const input = 'Author: Alice Developer <alice@example.com>';
+  const { text, hooks } = await scrub('git log', input, { tagFormat });
+  const part = { type: 'tool', state: { status: 'completed', input: { command: 'git log' }, output: text } };
+  const output = { messages: [{ info: { sessionID: 'vcs-test', role: 'assistant' }, parts: [part] }] };
+  await hooks['experimental.chat.messages.transform']!({}, output);
+  expect(part.state.output).toBe(text);
+  const args = { args: { command: part.state.output } };
+  await hooks['tool.execute.before']!({ tool: 'bash', sessionID: 'vcs-test', callID: 'call' }, args);
+  expect(args.args.command).toBe(input);
+});

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -164,7 +164,7 @@ describe("createDefaultPolicy", () => {
     expect(policy.enabledTypes.has(PIIType.PERSON)).toBe(true);
     expect(policy.enabledTypes.has(PIIType.PHONE)).toBe(true);
     expect(policy.enabledTypes.has(PIIType.IBAN)).toBe(true);
-    expect(policy.enabledTypes.size).toBe(18);
+    expect(policy.enabledTypes.size).toBe(19);
   });
 
   it("should have correct regex-enabled types", () => {

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -150,6 +150,8 @@ describe("createDefaultPolicy", () => {
   it("should create a policy with all non-secret types enabled", () => {
     const policy = createDefaultPolicy();
 
+    expect(policy.enabledTypes.has(PIIType.GITHUB_USERNAME)).toBe(true);
+
     // Secret types should NOT be enabled by default (opt-in only)
     expect(policy.enabledTypes.has(PIIType.API_KEY)).toBe(false);
     expect(policy.enabledTypes.has(PIIType.PRIVATE_KEY)).toBe(false);
@@ -164,7 +166,6 @@ describe("createDefaultPolicy", () => {
     expect(policy.enabledTypes.has(PIIType.PERSON)).toBe(true);
     expect(policy.enabledTypes.has(PIIType.PHONE)).toBe(true);
     expect(policy.enabledTypes.has(PIIType.IBAN)).toBe(true);
-    expect(policy.enabledTypes.has(PIIType.GITHUB_USERNAME)).toBe(true);
   });
 
   it("should have correct regex-enabled types", () => {

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -164,7 +164,7 @@ describe("createDefaultPolicy", () => {
     expect(policy.enabledTypes.has(PIIType.PERSON)).toBe(true);
     expect(policy.enabledTypes.has(PIIType.PHONE)).toBe(true);
     expect(policy.enabledTypes.has(PIIType.IBAN)).toBe(true);
-    expect(policy.enabledTypes.size).toBe(19);
+    expect(policy.enabledTypes.has(PIIType.GITHUB_USERNAME)).toBe(true);
   });
 
   it("should have correct regex-enabled types", () => {


### PR DESCRIPTION
GitHub participant logins and structured Git author names can reach the LLM provider in OpenCode tool output. Add opt-in `vcsIdentities` protection for direct `gh pr`, `gh api`, `git log`, `git show`, and `git blame` commands, including global options and compound commands.

Mask structured GitHub participant fields and mentions of discovered participants while preserving JSON keys and npm scopes. Detect author and committer names in Git headers and blame output, retaining stable, reversible placeholders through the session map. Respect `disableTypes`, preserve secret detection, and protect existing identity tags from being anonymized again when history is transformed repeatedly. Unstructured display names still need optional NER; commands hidden in shell scripts or aliases need separate integration.

Validation: all 1,531 tests pass. Added command-context, policy, raw-header, false-positive, repeated-session, and existing-placeholder regression tests, including custom tag formats. TypeScript build and lint pass with three existing warnings. The original contributor commits are preserved, with follow-up fixes from review.

Fixes #99

AI assistance: implementation, review, regression tests, and PR description.
