### PR TITLE
fix(opencode): load and discover project env files by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,9 @@
         "onnxruntime-web": {
           "optional": true
         }
+      },
+      "dependencies": {
+        "fast-glob": "^3.3.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -833,7 +836,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -847,7 +849,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -857,7 +858,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1849,7 +1849,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2542,7 +2541,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2586,7 +2584,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2616,7 +2613,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2997,7 +2993,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3017,7 +3012,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3030,7 +3024,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3296,7 +3289,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3306,7 +3298,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -3625,7 +3616,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3751,7 +3741,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3834,7 +3823,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -3922,7 +3910,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4413,7 +4400,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -142,5 +142,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "fast-glob": "^3.3.3"
   }
 }

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -20,7 +20,9 @@ Add to `opencode.json`:
 }
 ```
 
-By default, the plugin reads `.env` in your project root. Secrets with values of 4+ characters are detected and scrubbed.
+By default, the plugin discovers `**/.env*` under the OpenCode project directory, including files such as `packages/api/.env` and `apps/web/.env.local`. It skips `node_modules`, `.git`, and symbolic links. Secrets with values of 4+ characters are detected and scrubbed.
+
+`envFiles` accepts exact paths and glob patterns, resolved against the project directory even when OpenCode starts elsewhere. Use `envFiles: [".env"]` for root-only loading, or `envFiles: []` to disable file loading. Files are loaded once when the plugin initializes; restart OpenCode after changing them. Missing files are ignored. An advanced `anonymizer` configuration keeps control of its own `secrets` settings, with relative paths still rooted at the project directory unless `secrets.envBaseDirectory` is set.
 
 ## Configuration
 

--- a/src/core/anonymizer.ts
+++ b/src/core/anonymizer.ts
@@ -550,7 +550,10 @@ export class Anonymizer {
       // Parse .env files if provided
       if (this.secretsConfig.envFiles !== undefined && this.secretsConfig.envFiles.length > 0) {
         const storage = await getStorageProvider();
-        for (const envFile of this.secretsConfig.envFiles) {
+        const envFiles = storage.resolveFiles !== undefined
+          ? await storage.resolveFiles(this.secretsConfig.envFiles, this.secretsConfig.envBaseDirectory)
+          : this.secretsConfig.envFiles;
+        for (const envFile of envFiles) {
           try {
             const content = await storage.readTextFile(envFile);
             const parsed = parseEnvFile(content);

--- a/src/opencode-plugin/plugin.ts
+++ b/src/opencode-plugin/plugin.ts
@@ -121,12 +121,20 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
     const piiStorage = new InMemoryPIIStorageProvider();
 
     // Build anonymizer config from options, sharing key and storage providers
-    const anonymizerConfig = options?.anonymizer ?? {
+    const baseConfig = options?.anonymizer ?? {
       secrets: {
         enabled: true,
-        envFiles: options?.envFiles,
+        envFiles: options?.envFiles ?? ["**/.env*"],
         redactValues: options?.redactValues,
         minValueLength: options?.minValueLength,
+      },
+    };
+
+    const anonymizerConfig = {
+      ...baseConfig,
+      secrets: baseConfig.secrets === undefined ? undefined : {
+        ...baseConfig.secrets,
+        envBaseDirectory: baseConfig.secrets.envBaseDirectory ?? ctx.directory,
       },
     };
 
@@ -171,7 +179,7 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
     }
 
     log("info", "plugin initialized", {
-      envFiles: options?.envFiles,
+      envFiles: anonymizerConfig.secrets?.envFiles,
       redactValueCount: options?.redactValues?.length ?? 0,
       disableTypes,
     });

--- a/src/opencode-plugin/types.ts
+++ b/src/opencode-plugin/types.ts
@@ -13,7 +13,8 @@ export type PIITypeName = `${PIIType}`;
  * Configuration options for the Rehydra OpenCode plugin.
  */
 export interface RehydraPluginOptions {
-  /** .env files to scan for secret values */
+  /** Paths/globs relative to the OpenCode project directory. Defaults to recursive .env discovery.
+   * Skips node_modules, .git, and symlinks. Pass [] to disable file loading. */
   envFiles?: string[];
 
   /** Explicit values to always redact */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -284,8 +284,10 @@ export interface AnonymizationResult {
 export interface SecretsConfig {
   /** Enable secrets/credentials detection */
   enabled: boolean;
-  /** .env file paths to parse for known secret values */
+  /** .env file paths or Node.js glob patterns to parse for known secret values */
   envFiles?: string[];
+  /** Base directory for Node.js envFiles paths/globs. Defaults to process.cwd(). */
+  envBaseDirectory?: string;
   /** Explicit values to always redact */
   redactValues?: string[];
   /** Additional key name patterns for ENV_VAR_SECRET / CONFIG_SECRET detection */

--- a/src/utils/storage-node.ts
+++ b/src/utils/storage-node.ts
@@ -6,6 +6,7 @@
 import * as fs from "fs/promises";
 import * as nodePath from "path";
 import * as os from "os";
+import glob from "fast-glob";
 import type { StorageProvider } from "./storage.js";
 
 /**
@@ -28,6 +29,27 @@ export class NodeStorageProvider implements StorageProvider {
     // Handle latin1 encoding (used by nam_dict.txt)
     const nodeEncoding = encoding === "latin1" ? "latin1" : "utf-8";
     return fs.readFile(path, { encoding: nodeEncoding as BufferEncoding });
+  }
+
+  async resolveFiles(patterns: string[], baseDirectory?: string): Promise<string[]> {
+    const cwd = baseDirectory ?? process.cwd();
+    // Preserve existing literal paths containing glob metacharacters.
+    const inputs = await Promise.all(patterns.map(async (pattern) => {
+      if (await this.exists(nodePath.resolve(cwd, pattern))) {
+        return glob.convertPathToPattern(pattern);
+      }
+      return pattern;
+    }));
+    if (inputs.length === 0) return [];
+    return (await glob(inputs, {
+      cwd,
+      absolute: true,
+      dot: true,
+      onlyFiles: true,
+      followSymbolicLinks: false,
+      unique: true,
+      ignore: ["**/node_modules/**", "**/.git/**"],
+    })).sort();
   }
 
   /**

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -19,6 +19,10 @@ export interface StorageProvider {
    */
   readTextFile(path: string, encoding?: string): Promise<string>;
 
+  /** Resolve file paths/globs relative to a directory. Optional for virtual storage.
+   * Node discovery skips node_modules, .git, and symbolic links. */
+  resolveFiles?(patterns: string[], baseDirectory?: string): Promise<string[]>;
+
   /**
    * Writes data to a file
    * Creates parent directories if they don't exist

--- a/test/opencode-plugin/env-files.test.ts
+++ b/test/opencode-plugin/env-files.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRehydraPlugin } from "../../src/opencode-plugin/plugin.js";
+import { NodeStorageProvider } from "../../src/utils/storage-node.js";
+import { createAnonymizer } from "../../src/index.js";
+import type { RehydraPluginOptions } from "../../src/opencode-plugin/types.js";
+
+let directory: string;
+async function fixture(path: string, value: string): Promise<void> {
+  const full = join(directory, path);
+  await mkdir(dirname(full), { recursive: true });
+  await writeFile(full, `TOKEN=${value}\n`);
+}
+async function scrub(text: string, options?: RehydraPluginOptions): Promise<string> {
+  const hooks = await createRehydraPlugin(options)({
+    directory, worktree: directory,
+    client: { app: { log: async () => {} } },
+  });
+  const output = { messages: [{ info: { sessionID: "env-test", role: "user" },
+    parts: [{ type: "text", text, sessionID: "env-test", messageID: "msg-1" }],
+  }] };
+  await hooks["experimental.chat.messages.transform"]!({}, output);
+  return output.messages[0]!.parts[0]!.text;
+}
+
+beforeEach(async () => { directory = await mkdtemp(join(tmpdir(), "rehydra-env-test-")); });
+afterEach(async () => { await rm(directory, { recursive: true, force: true }); });
+
+describe("project env file discovery", () => {
+  it("loads root and nested env values with zero config, independently of cwd", async () => {
+    await fixture(".env", "root-secret-value");
+    await fixture("packages/api/.env.local", "nested-secret-value");
+    const result = await scrub("root-secret-value nested-secret-value");
+    expect(result).not.toContain("root-secret-value");
+    expect(result).not.toContain("nested-secret-value");
+    expect(result.match(/ENV_VAR_SECRET/g)).toHaveLength(2);
+  });
+
+  it("does not scan dependencies, git metadata, or symlinked directories", async () => {
+    await fixture("node_modules/pkg/.env", "dependency-secret-value");
+    await fixture("packages/api/node_modules/pkg/.env", "nested-dependency-secret");
+    await fixture(".git/.env", "git-secret-value");
+    await fixture("outside/secrets", "linked-secret-value");
+    await symlink(join(directory, "outside"), join(directory, "linked"), "dir");
+    await symlink(join(directory, "outside/secrets"), join(directory, ".env.link"));
+    const text = "dependency-secret-value nested-dependency-secret git-secret-value linked-secret-value";
+    expect(await scrub(text)).toBe(text);
+  });
+
+  it("allows opting out with an empty array", async () => {
+    await fixture(".env", "root-secret-value");
+    expect(await scrub("root-secret-value", { envFiles: [] })).toBe("root-secret-value");
+  });
+
+  it("honors exact paths without adding defaults", async () => {
+    await fixture(".env", "root-secret-value");
+    await fixture("app/custom.env", "custom-secret-value");
+    const result = await scrub("root-secret-value custom-secret-value", { envFiles: ["app/custom.env"] });
+    expect(result).toContain("root-secret-value");
+    expect(result).not.toContain("custom-secret-value");
+  });
+
+  it("supports braces, exclusions, duplicate matches, and literal metacharacters", async () => {
+    await fixture("app/.env.local", "included-secret-value");
+    await fixture("app/.env.test", "excluded-secret-value");
+    await fixture("[app]/.env", "bracket-secret-value");
+    const storage = new NodeStorageProvider();
+    expect(await storage.resolveFiles(["app/.env.{local,test}", "!app/.env.test", "app/.env.local", "[app]/.env"], directory))
+      .toEqual([join(directory, "[app]/.env"), join(directory, "app/.env.local")].sort());
+  });
+
+  it("accepts absolute paths and tolerates missing files and no matches", async () => {
+    await fixture(".env", "absolute-secret-value");
+    const result = await scrub("absolute-secret-value", { envFiles: [join(directory, ".env"), "missing", "nothing/*.env"] });
+    expect(result).not.toContain("absolute-secret-value");
+  });
+
+  it("preserves an advanced config opt-out", async () => {
+    await fixture(".env", "root-secret-value");
+    expect(await scrub("root-secret-value", { anonymizer: { secrets: { enabled: false } } })).toBe("root-secret-value");
+  });
+
+  it("roots advanced config paths at the project directory", async () => {
+    await fixture(".env", "advanced-secret-value");
+    expect(await scrub("advanced-secret-value", { anonymizer: { secrets: { enabled: true, envFiles: [".env"] } } }))
+      .not.toContain("advanced-secret-value");
+  });
+
+  it("lets advanced consumers override the scan root", async () => {
+    await fixture("nested/.env", "override-secret-value");
+    expect(await scrub("override-secret-value", { anonymizer: { secrets: {
+      enabled: true, envFiles: [".env"], envBaseDirectory: join(directory, "nested"),
+    } } })).not.toContain("override-secret-value");
+  });
+
+  it("expands envFiles globs for standalone SDK consumers too", async () => {
+    await fixture("nested/.env.local", "sdk-secret-value");
+    const anonymizer = createAnonymizer({ secrets: { enabled: true, envFiles: ["**/.env*"], envBaseDirectory: directory } });
+    try {
+      await anonymizer.initialize();
+      expect((await anonymizer.anonymize("sdk-secret-value")).anonymizedText).not.toContain("sdk-secret-value");
+    } finally { await anonymizer.dispose(); }
+  });
+});


### PR DESCRIPTION
OpenCode's default configuration never loaded `.env` values despite the documented promise. `envFiles` also treated glob patterns as literal filenames and resolved paths against the process working directory.

Load `**/.env*` under the OpenCode project directory by default. Support exact paths, glob patterns, and exclusions for both the plugin and standalone SDK, with an optional `envBaseDirectory`. Discovery skips `node_modules`, `.git`, and symlinks. Explicit `envFiles: []` disables loading, and advanced anonymizer configurations retain control of their secrets settings. Files are loaded at initialization; this does not add file watching.

Validation: reproduced the missing default and literal-glob failures before the change; added 10 filesystem/plugin regression tests; all 1,519 tests pass; TypeScript build and lint pass with three existing warnings; browser Vite bundle builds without Node modules.

Fixes #96
Fixes #98
