### PR TITLE
feat(proxy): support streaming server-side tool loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Beyond names, emails, and phone numbers, Rehydra detects API keys (OpenAI, Anthr
 
 Purpose-built for LLM token streams. A sentence-buffered chunking system with NER overlap preservation ensures accurate detection even when PII spans chunk boundaries — with a low-latency mode for real-time streaming.
 
+### Streaming server-side tool loops
+
+`createRehydraFetch` supports `onToolCall` for OpenAI Chat Completions and Anthropic Messages requests with `stream: true`. The first response is buffered and its complete tool calls are validated before callbacks run. Interleaved calls retain their IDs and arguments. Tool arguments are rehydrated locally, and tool results are anonymized before the next request.
+
+Continuation requests use `stream: false`. The final response is returned as provider-compatible SSE, including completion events and usage. This buffers the initial response and final JSON response, so it does not preserve token-by-token generation latency. Streams without tool calls retain their original events.
+
+Set `maxToolRounds` to bound callback rounds, and `maxToolResponseBytes` to bound each buffered response; defaults are 10 rounds and 8 MiB. On reaching the round limit, pending calls are returned to the caller without execution. Pass an `AbortSignal` through fetch to cancel buffering or prevent later callbacks; a callback already running must manage its own cancellation. Truncated calls, malformed arguments, and oversized streams fail before tool execution. Upstream HTTP errors retain their status. OpenAI tool loops require a single completion choice. Custom providers can opt in through `streamingToolLoop` on `LLMContentProvider`.
+
 ### Semantic enrichment for machine translation
 
 Optional gender and scope attributes on PII tags (`<PII type="PERSON" gender="male" id="1"/>`, `<PII type="LOCATION" scope="city" id="2"/>`) preserve grammatical context for downstream systems.

--- a/src/proxy/providers/anthropic.ts
+++ b/src/proxy/providers/anthropic.ts
@@ -1,3 +1,4 @@
+import { anthropicStreamingToolLoop } from "./streaming-tool-loop.js";
 /**
  * Anthropic Content Provider
  * Handles Anthropic Messages API format.
@@ -54,6 +55,7 @@ interface AnthropicStreamEvent {
 
 export class AnthropicProvider implements LLMContentProvider {
   readonly name = "anthropic";
+  readonly streamingToolLoop = anthropicStreamingToolLoop;
 
   matchesRequest(url: string, headers: Headers): boolean {
     if (url.includes("api.anthropic.com")) return true;

--- a/src/proxy/providers/openai.ts
+++ b/src/proxy/providers/openai.ts
@@ -1,3 +1,4 @@
+import { openAIStreamingToolLoop } from "./streaming-tool-loop.js";
 /**
  * OpenAI Content Provider
  * Handles OpenAI Chat Completions API format.
@@ -74,6 +75,7 @@ interface OpenAIStreamChunk {
 
 export class OpenAIProvider implements LLMContentProvider {
   readonly name = "openai";
+  readonly streamingToolLoop = openAIStreamingToolLoop;
 
   matchesRequest(url: string, headers: Headers): boolean {
     if (url.includes("api.openai.com")) return true;
@@ -286,6 +288,7 @@ export class OpenAIProvider implements LLMContentProvider {
       ...(originalBody as Record<string, unknown>),
       messages: newMessages,
       stream: false,
+      stream_options: undefined,
     };
   }
 

--- a/src/proxy/providers/streaming-tool-loop.ts
+++ b/src/proxy/providers/streaming-tool-loop.ts
@@ -169,11 +169,16 @@ export const anthropicStreamingToolLoop: StreamingToolLoopAdapter = {
     for (const [i, item] of response.content.entries()) {
       const block = object(item);
       const start = { ...block };
-      let delta: ObjectValue | undefined;
-      if (block.type === 'text') { start.text = ''; delta = { type: 'text_delta', text: block.text }; }
-      if (block.type === 'tool_use') { start.input = {}; delta = { type: 'input_json_delta', partial_json: JSON.stringify(block.input) }; }
+      const deltas: ObjectValue[] = [];
+      if (block.type === 'text') { start.text = ''; deltas.push({ type: 'text_delta', text: block.text }); }
+      if (block.type === 'tool_use') { start.input = {}; deltas.push({ type: 'input_json_delta', partial_json: JSON.stringify(block.input) }); }
+      if (block.type === 'thinking') {
+        start.thinking = ''; start.signature = '';
+        deltas.push({ type: 'thinking_delta', thinking: block.thinking });
+        if (typeof block.signature === 'string') deltas.push({ type: 'signature_delta', signature: block.signature });
+      }
       yield event({ type: 'content_block_start', index: i, content_block: start }, 'content_block_start');
-      if (delta !== undefined) yield event({ type: 'content_block_delta', index: i, delta }, 'content_block_delta');
+      for (const delta of deltas) yield event({ type: 'content_block_delta', index: i, delta }, 'content_block_delta');
       yield event({ type: 'content_block_stop', index: i }, 'content_block_stop');
     }
     yield event({ type: 'message_delta', delta: { stop_reason: response.stop_reason, stop_sequence: response.stop_sequence }, usage: response.usage ?? {} }, 'message_delta');

--- a/src/proxy/providers/streaming-tool-loop.ts
+++ b/src/proxy/providers/streaming-tool-loop.ts
@@ -1,0 +1,182 @@
+import type { SSEEvent } from '../sse-parser.js';
+
+/** A provider-specific conversion between SSE and complete tool-loop responses. */
+export interface StreamingToolLoopAdapter {
+  createAccumulator(): { push(data: unknown): void; finish(): unknown };
+  encode(body: unknown): Iterable<SSEEvent>;
+}
+
+type ObjectValue = Record<string, unknown>;
+function object(value: unknown): ObjectValue {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid streaming response object');
+  }
+  return value as ObjectValue;
+}
+function index(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error('Invalid streaming response index');
+  }
+  return value;
+}
+function append(target: ObjectValue, key: string, value: unknown): void {
+  if (typeof value === 'string') target[key] = String(target[key] ?? '') + value;
+}
+function event(data: unknown, type = 'message'): SSEEvent {
+  return { event: type, data: JSON.stringify(data) };
+}
+function validateTool(id: unknown, name: unknown, args: string): void {
+  if (typeof id !== 'string' || id === '' || typeof name !== 'string' || name === '') {
+    throw new Error('Incomplete streamed tool call');
+  }
+  object(JSON.parse(args));
+}
+
+export const openAIStreamingToolLoop: StreamingToolLoopAdapter = {
+  createAccumulator() {
+    const metadata: ObjectValue = {};
+    const message: ObjectValue = { role: 'assistant', content: '' };
+    const calls = new Map<number, { id: string; type: string; function: { name: string; arguments: string } }>();
+    let finishReason: unknown;
+    return {
+      push(data): void {
+        const chunk = object(data);
+        if (chunk.error !== undefined) throw new Error('Upstream streaming error');
+        for (const key of ['id', 'model', 'created', 'system_fingerprint', 'usage']) {
+          if (chunk[key] !== undefined) metadata[key] = chunk[key];
+        }
+        if (!Array.isArray(chunk.choices)) throw new Error('Missing streaming choices');
+        for (const value of chunk.choices) {
+          const choice = object(value);
+          if (index(choice.index) !== 0) throw new Error('Streaming tool loops require a single completion choice');
+          const delta = object(choice.delta);
+          if (choice.finish_reason !== undefined && choice.finish_reason !== null) finishReason = choice.finish_reason;
+          for (const key of ['content', 'refusal', 'reasoning_content']) append(message, key, delta[key]);
+          if (Array.isArray(delta.tool_calls)) for (const item of delta.tool_calls) {
+            const fragment = object(item);
+            const i = index(fragment.index);
+            const call = calls.get(i) ?? { id: '', type: 'function', function: { name: '', arguments: '' } };
+            append(call, 'id', fragment.id);
+            if (fragment.function !== undefined) {
+              const fn = object(fragment.function);
+              append(call.function, 'name', fn.name);
+              append(call.function, 'arguments', fn.arguments);
+            }
+            calls.set(i, call);
+          }
+        }
+      },
+      finish(): unknown {
+        if (finishReason === undefined) throw new Error('Truncated streaming completion');
+        if (calls.size > 0) {
+          if (finishReason !== 'tool_calls') throw new Error('Streamed tool calls did not complete');
+          const tools = [...calls].sort(([a], [b]) => a - b).map(([, call]) => call);
+          if (new Set(tools.map(call => call.id)).size !== tools.length) throw new Error('Duplicate streamed tool call ID');
+          for (const call of tools) validateTool(call.id, call.function.name, call.function.arguments);
+          message.tool_calls = tools;
+        }
+        return { ...metadata, object: 'chat.completion', choices: [{ index: 0, message, finish_reason: finishReason }] };
+      },
+    };
+  },
+  *encode(body) {
+    const response = object(body);
+    if (!Array.isArray(response.choices)) throw new Error('Missing completion choices');
+    const metadata = { ...response, object: 'chat.completion.chunk', usage: undefined };
+    for (const value of response.choices) {
+      const choice = object(value);
+      const message = object(choice.message);
+      const delta = { ...message };
+      if (Array.isArray(message.tool_calls)) delta.tool_calls = message.tool_calls.map((call, i) => ({ ...object(call), index: i }));
+      yield event({ ...metadata, choices: [{ index: choice.index ?? 0, delta, finish_reason: null }] });
+      yield event({ ...metadata, choices: [{ index: choice.index ?? 0, delta: {}, finish_reason: choice.finish_reason }] });
+    }
+    if (response.usage !== undefined) yield event({ ...metadata, choices: [], usage: response.usage });
+    yield { event: 'message', data: '[DONE]' };
+  },
+};
+
+export const anthropicStreamingToolLoop: StreamingToolLoopAdapter = {
+  createAccumulator() {
+    let message: ObjectValue | undefined;
+    const blocks = new Map<number, ObjectValue>();
+    const args = new Map<number, string>();
+    const stoppedBlocks = new Set<number>();
+    let stopped = false;
+    return {
+      push(data): void {
+        const value = object(data);
+        if (value.type === 'error') throw new Error('Upstream streaming error');
+        switch (value.type) {
+          case 'message_start':
+            if (message !== undefined) throw new Error('Duplicate message start');
+            message = { ...object(value.message) }; break;
+          case 'content_block_start': {
+            const i = index(value.index);
+            if (blocks.has(i)) throw new Error('Duplicate content block');
+            blocks.set(i, { ...object(value.content_block) });
+            break;
+          }
+          case 'content_block_delta': {
+            const i = index(value.index);
+            const block = blocks.get(i);
+            if (block === undefined || stoppedBlocks.has(i)) throw new Error('Unexpected content delta');
+            const delta = object(value.delta);
+            if (delta.type === 'input_json_delta') {
+              if (typeof delta.partial_json !== 'string') throw new Error('Invalid tool argument delta');
+              args.set(i, (args.get(i) ?? '') + delta.partial_json);
+            } else if (delta.type === 'text_delta') append(block, 'text', delta.text);
+            else if (delta.type === 'thinking_delta') append(block, 'thinking', delta.thinking);
+            else if (delta.type === 'signature_delta') append(block, 'signature', delta.signature);
+            else throw new Error('Unsupported content delta in streaming tool loop');
+            break;
+          }
+          case 'content_block_stop': {
+            const i = index(value.index);
+            if (!blocks.has(i) || stoppedBlocks.has(i)) throw new Error('Unexpected content block stop');
+            stoppedBlocks.add(i); break;
+          }
+          case 'message_delta':
+            if (message === undefined) throw new Error('Missing message start');
+            Object.assign(message, object(value.delta));
+            if (value.usage !== undefined) message.usage = { ...object(message.usage ?? {}), ...object(value.usage) };
+            break;
+          case 'message_stop': stopped = true; break;
+        }
+      },
+      finish(): unknown {
+        if (message === undefined || !stopped) throw new Error('Truncated streaming message');
+        const content = [...blocks].sort(([a], [b]) => a - b).map(([i, block]) => {
+          if (!stoppedBlocks.has(i)) throw new Error('Unfinished content block');
+          if (block.type === 'tool_use') {
+            if (message!.stop_reason !== 'tool_use') throw new Error('Streamed tool calls did not complete');
+            const json = args.get(i) ?? JSON.stringify(block.input ?? {});
+            validateTool(block.id, block.name, json);
+            block.input = JSON.parse(json) as unknown;
+          }
+          return block;
+        });
+        const ids = content.filter(block => block.type === 'tool_use').map(block => block.id);
+        if (new Set(ids).size !== ids.length) throw new Error('Duplicate streamed tool call ID');
+        return { ...message, content };
+      },
+    };
+  },
+  *encode(body) {
+    const response = object(body);
+    if (!Array.isArray(response.content)) throw new Error('Missing message content');
+    yield event({ type: 'message_start', message: { ...response, content: [], stop_reason: null, stop_sequence: null } }, 'message_start');
+    for (const [i, item] of response.content.entries()) {
+      const block = object(item);
+      const start = { ...block };
+      let delta: ObjectValue | undefined;
+      if (block.type === 'text') { start.text = ''; delta = { type: 'text_delta', text: block.text }; }
+      if (block.type === 'tool_use') { start.input = {}; delta = { type: 'input_json_delta', partial_json: JSON.stringify(block.input) }; }
+      yield event({ type: 'content_block_start', index: i, content_block: start }, 'content_block_start');
+      if (delta !== undefined) yield event({ type: 'content_block_delta', index: i, delta }, 'content_block_delta');
+      yield event({ type: 'content_block_stop', index: i }, 'content_block_stop');
+    }
+    yield event({ type: 'message_delta', delta: { stop_reason: response.stop_reason, stop_sequence: response.stop_sequence }, usage: response.usage ?? {} }, 'message_delta');
+    yield event({ type: 'message_stop' }, 'message_stop');
+  },
+};

--- a/src/proxy/providers/types.ts
+++ b/src/proxy/providers/types.ts
@@ -1,3 +1,4 @@
+import type { StreamingToolLoopAdapter } from './streaming-tool-loop.js';
 /**
  * LLM Content Provider Interface
  * Abstracts LLM-specific request/response formats for the proxy middleware.
@@ -44,6 +45,9 @@ export interface ToolCallDelta {
 export interface LLMContentProvider {
   /** Provider name (e.g., "openai", "anthropic") */
   readonly name: string;
+
+  /** Optional SSE conversion for server-side tool execution loops. */
+  readonly streamingToolLoop?: StreamingToolLoopAdapter;
 
   /** Detect if a request matches this provider based on URL/headers */
   matchesRequest(url: string, headers: Headers): boolean;

--- a/src/proxy/rehydra-fetch.ts
+++ b/src/proxy/rehydra-fetch.ts
@@ -15,6 +15,7 @@ import type { LLMContentProvider, ToolResultMessage } from "./providers/types.js
 import type { RehydraFetchConfig } from "./types.js";
 import { buildPIISystemInstruction } from "./system-instruction.js";
 import { buildTagPrefix } from "../utils/regex.js";
+import { accumulateToolStream, readToolResponse, toolResultStream } from "./tool-loop-stream.js";
 import { DEFAULT_TAG_FORMAT } from "../types/index.js";
 
 /** Headers to strip from proxied responses — the body is decompressed and may be modified. */
@@ -89,6 +90,14 @@ function errorResponse(status: number, message: string): Response {
 export function createRehydraFetch(
   config: RehydraFetchConfig,
 ): typeof globalThis.fetch {
+  if (config.maxToolRounds !== undefined &&
+    (!Number.isSafeInteger(config.maxToolRounds) || config.maxToolRounds < 0)) {
+    throw new Error("maxToolRounds must be a nonnegative safe integer");
+  }
+  if (config.maxToolResponseBytes !== undefined &&
+    (!Number.isSafeInteger(config.maxToolResponseBytes) || config.maxToolResponseBytes <= 0)) {
+    throw new Error("maxToolResponseBytes must be a positive safe integer");
+  }
   const anonymizer = createAnonymizer({
     ...config.anonymizer,
     keyProvider: config.keyProvider,
@@ -228,6 +237,8 @@ export function createRehydraFetch(
         return errorResponse(502, `Upstream LLM unreachable: ${msg}`);
       }
 
+      if (!response.ok) return response;
+
       // Determine if the response is a streaming SSE response
       const responseContentType = response.headers.get("content-type");
       const isSSE =
@@ -237,6 +248,11 @@ export function createRehydraFetch(
         responseContentType.includes("text/event-stream");
 
       if (isSSE && response.body !== null) {
+        if (config.onToolCall !== undefined && provider.streamingToolLoop !== undefined &&
+          provider.hasResponseToolCalls !== undefined && provider.extractResponseToolCallInfo !== undefined &&
+          provider.extractMessages !== undefined && provider.buildToolLoopBody !== undefined && response.ok) {
+          return await handleStreamingToolLoop(response, anonymizedBody, session, provider, config, request);
+        }
         return rehydrateSSEResponse(response, session, provider, config);
       }
 
@@ -261,11 +277,51 @@ export function createRehydraFetch(
 
       return rehydrateJSONResponse(response, session, provider);
     } catch (err) {
+      if (request.signal.aborted) throw err;
       const msg =
         err instanceof Error ? err.message : "Internal proxy error";
       return errorResponse(500, msg);
     }
   };
+}
+
+/** Buffer and validate the first stream before allowing any tool side effects. */
+async function handleStreamingToolLoop(
+  response: Response,
+  anonymizedBody: unknown,
+  session: AnonymizerSessionImpl,
+  provider: LLMContentProvider,
+  config: RehydraFetchConfig,
+  request: Request,
+): Promise<Response> {
+  const adapter = provider.streamingToolLoop!;
+  let text: string;
+  let complete: unknown;
+  try {
+    text = await readToolResponse(response, config.maxToolResponseBytes ?? 8 * 1024 * 1024, request.signal);
+    complete = accumulateToolStream(text, adapter);
+  } catch (err) {
+    if (request.signal.aborted) throw err;
+    return errorResponse(502, err instanceof Error ? err.message : "Invalid streamed tool response");
+  }
+  if (!provider.hasResponseToolCalls!(complete)) {
+    return rehydrateSSEResponse(new Response(text, {
+      status: response.status, headers: stripResponseHeaders(response.headers),
+    }), session, provider, config);
+  }
+  const headers = stripResponseHeaders(response.headers);
+  headers.set("content-type", "application/json");
+  const finalResponse = await handleToolLoop(new Response(JSON.stringify(complete), {
+    status: response.status, headers,
+  }), anonymizedBody, session, provider, config, request);
+  if (!finalResponse.ok) return finalResponse;
+  let finalBody: unknown;
+  try {
+    finalBody = await finalResponse.json();
+  } catch {
+    return errorResponse(502, "Invalid JSON in tool-loop response");
+  }
+  return toolResultStream(finalBody, finalResponse, adapter);
 }
 
 /**
@@ -362,7 +418,9 @@ async function handleToolLoop(
   const maxRounds = config.maxToolRounds ?? 10;
 
   // Parse the initial response
-  const rawText = await initialResponse.text();
+  const readResponse = (response: Response): Promise<string> =>
+    readToolResponse(response, config.maxToolResponseBytes ?? 8 * 1024 * 1024, originalRequest.signal);
+  const rawText = await readResponse(initialResponse);
   let currentResponse: unknown;
   try {
     currentResponse = JSON.parse(rawText);
@@ -403,19 +461,22 @@ async function handleToolLoop(
     const toolResults: ToolResultMessage[] = [];
     for (const tc of toolCallInfos) {
       // Rehydrate the arguments string to restore real PII
-      const rehydratedArgsStr = await session.rehydrate(tc.arguments);
+      originalRequest.signal.throwIfAborted();
       let parsedArgs: Record<string, unknown>;
       try {
-        parsedArgs = JSON.parse(rehydratedArgsStr) as Record<string, unknown>;
+        const args = JSON.parse(tc.arguments) as Record<string, unknown>;
+        parsedArgs = await session.rehydrateJson(args);
       } catch {
-        parsedArgs = { raw: rehydratedArgsStr };
+        parsedArgs = { raw: await session.rehydrate(tc.arguments) };
       }
+      originalRequest.signal.throwIfAborted();
 
       // Call the user's tool handler with real PII
       const result = await config.onToolCall!(tc.name, parsedArgs, tc.id);
 
       // Anonymize the result using the same session (maintains PII ID continuity)
-      const anonymizedResult = await session.anonymizeJson(result);
+      originalRequest.signal.throwIfAborted();
+      const anonymizedResult = await session.anonymizeJson(result, config.locale, config.policy);
 
       toolResults.push({
         toolCallId: tc.id,
@@ -486,7 +547,11 @@ async function handleToolLoop(
     lastUpstreamResponse = nextResponse;
 
     // Parse the new response
-    const nextRawText = await nextResponse.text();
+    const nextRawText = await readResponse(nextResponse);
+    if (!nextResponse.ok) return new Response(nextRawText, {
+      status: nextResponse.status, statusText: nextResponse.statusText,
+      headers: stripResponseHeaders(nextResponse.headers),
+    });
     try {
       currentResponse = JSON.parse(nextRawText);
     } catch {

--- a/src/proxy/tool-loop-stream.ts
+++ b/src/proxy/tool-loop-stream.ts
@@ -1,0 +1,60 @@
+import { SSEParser, isSSEDone, serializeSSEEvent } from './sse-parser.js';
+import type { StreamingToolLoopAdapter } from './providers/streaming-tool-loop.js';
+
+/** Buffer one response with a byte limit and cancellation, including incomplete SSE events. */
+export async function readToolResponse(response: Response, limit: number, signal: AbortSignal): Promise<string> {
+  signal.throwIfAborted();
+  if (response.body === null) return '';
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = '';
+  const cancel = (): void => { void reader.cancel().catch(() => {}); };
+  signal.addEventListener('abort', cancel, { once: true });
+  try {
+    for (;;) {
+      signal.throwIfAborted();
+      const { value, done } = await reader.read();
+      signal.throwIfAborted();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > limit) throw new Error('Tool response exceeds maxToolResponseBytes');
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } catch (error) {
+    cancel();
+    throw error;
+  } finally {
+    signal.removeEventListener('abort', cancel);
+    reader.releaseLock();
+  }
+}
+
+export function accumulateToolStream(text: string, adapter: StreamingToolLoopAdapter): unknown {
+  const parser = new SSEParser();
+  const accumulator = adapter.createAccumulator();
+  for (const event of [...parser.parse(text), ...parser.flush()]) {
+    if (isSSEDone(event.data)) continue;
+    accumulator.push(JSON.parse(event.data) as unknown);
+  }
+  return accumulator.finish();
+}
+
+/** Generate frames on demand so downstream consumption controls backpressure. */
+export function toolResultStream(body: unknown, response: Response, adapter: StreamingToolLoopAdapter): Response {
+  const frames = adapter.encode(body)[Symbol.iterator]();
+  const encoder = new TextEncoder();
+  const headers = new Headers(response.headers);
+  headers.delete('content-length');
+  headers.delete('content-encoding');
+  headers.set('content-type', 'text/event-stream');
+  return new Response(new ReadableStream<Uint8Array>({
+    pull(controller): void {
+      const next = frames.next();
+      if (next.done === true) controller.close();
+      else controller.enqueue(encoder.encode(serializeSSEEvent(next.value)));
+    },
+    cancel(): void { frames.return?.(); },
+  }), { status: response.status, statusText: response.statusText, headers });
+}

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -86,7 +86,7 @@ export interface RehydraFetchConfig {
 
   /**
    * Callback for executing tool calls in an agentic loop.
-   * When provided and the LLM returns tool calls (non-streaming), the proxy will:
+   * When provided and the LLM returns tool calls, the proxy will:
    * 1. Rehydrate tool call arguments (restore real PII)
    * 2. Call this callback for each tool call
    * 3. Anonymize the return value
@@ -94,7 +94,9 @@ export interface RehydraFetchConfig {
    * 5. Repeat until the LLM returns a final response (no tool calls)
    *
    * The callback receives real PII values — it runs on your server, not the LLM.
-   * Non-streaming only (streaming tool loops are not yet supported).
+   * OpenAI and Anthropic streaming responses are buffered before tools run.
+   * Later rounds use JSON; the final result is emitted as provider-compatible SSE.
+   * Single-completion requests only. Cancellation prevents further tool calls.
    */
   onToolCall?: OnToolCallFn;
 
@@ -104,6 +106,9 @@ export interface RehydraFetchConfig {
    * @default 10
    */
   maxToolRounds?: number;
+
+  /** Maximum bytes buffered per response in a tool loop. Default: 8 MiB. */
+  maxToolResponseBytes?: number;
 
   /**
    * Hook invoked once per intercepted request, after anonymization and

--- a/test/proxy/streaming-tool-loop.test.ts
+++ b/test/proxy/streaming-tool-loop.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRehydraFetch } from '../../src/proxy/rehydra-fetch.js';
+import { InMemoryKeyProvider } from '../../src/crypto/index.js';
+import { InMemoryPIIStorageProvider } from '../../src/storage/in-memory.js';
+import { SSEParser, isSSEDone } from '../../src/proxy/sse-parser.js';
+import type { RehydraFetchConfig } from '../../src/proxy/types.js';
+import { anthropicStreamingToolLoop, openAIStreamingToolLoop } from '../../src/proxy/providers/streaming-tool-loop.js';
+
+const email = 'alice@example.com';
+const frames = (values: unknown[]): string => values.map(v => `data: ${typeof v === 'string' ? v : JSON.stringify(v)}\n\n`).join('');
+function sse(text: string): Response {
+  const bytes = new TextEncoder().encode(text);
+  let offset = 0;
+  return new Response(new ReadableStream({ pull(c) {
+    if (offset === bytes.length) { c.close(); return; }
+    c.enqueue(bytes.slice(offset, offset + 3)); offset = Math.min(bytes.length, offset + 3);
+  } }), { headers: { 'content-type': 'text/event-stream', 'x-request-id': 'trace' } });
+}
+function openaiCalls(arg: string): unknown[] {
+  return [
+    { id: 'c1', model: 'model', choices: [{ index: 0, delta: { role: 'assistant', tool_calls: [
+      { index: 0, id: 'tool-0', type: 'function', function: { name: 'lookup', arguments: arg.slice(0, 9) } },
+      { index: 1, id: 'tool-1', type: 'function', function: { name: 'lookup', arguments: arg.slice(0, 4) } },
+    ] } }] },
+    { choices: [{ index: 0, delta: { tool_calls: [{ index: 1, function: { arguments: arg.slice(4) } }, { index: 0, function: { arguments: arg.slice(9) } }] } }] },
+    { choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+    '[DONE]',
+  ];
+}
+function anthropicCalls(arg: string): unknown[] {
+  return [
+    { type: 'message_start', message: { id: 'm1', role: 'assistant', model: 'model', type: 'message', usage: { input_tokens: 12 } } },
+    { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tool-0', name: 'lookup', input: {} } },
+    { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'tool-1', name: 'lookup', input: {} } },
+    { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: arg.slice(0, 4) } },
+    { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: arg } },
+    { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: arg.slice(4) } },
+    { type: 'content_block_stop', index: 0 }, { type: 'content_block_stop', index: 1 },
+    { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 20 } },
+    { type: 'message_stop' },
+  ];
+}
+function client(overrides: Partial<RehydraFetchConfig> = {}) {
+  return createRehydraFetch({ keyProvider: new InMemoryKeyProvider(), piiStorageProvider: new InMemoryPIIStorageProvider(), ...overrides });
+}
+function request(provider: 'openai' | 'anthropic', signal?: AbortSignal) {
+  return new Request(`https://example.test/${provider}`, { method: 'POST', signal,
+    headers: { 'content-type': 'application/json' }, body: JSON.stringify({ model: 'model', stream: true,
+      messages: [{ role: 'user', content: email }],
+    }),
+  });
+}
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe.each(['openai', 'anthropic'] as const)('%s streaming tool loops', (provider) => {
+  const calls = provider === 'openai' ? openaiCalls : anthropicCalls;
+  const adapter = provider === 'openai' ? openAIStreamingToolLoop : anthropicStreamingToolLoop;
+
+  it('executes interleaved calls, scrubs new tool results, and returns a rehydrated SSE response', async () => {
+    const onToolCall = vi.fn().mockResolvedValue({ email: 'bob@example.com' });
+    let round = 0;
+    vi.stubGlobal('fetch', vi.fn(async (req: Request) => {
+      const text = await req.text();
+      const body = JSON.parse(text);
+      expect(text).not.toContain(email);
+      expect(text).not.toContain('bob@example.com');
+      if (round++ === 0) {
+        expect(body.stream).toBe(true);
+        const masked = body.messages.find((m: {role: string}) => m.role === 'user').content;
+        return sse(frames(calls(JSON.stringify({ email: masked }))));
+      }
+      expect(body.stream).toBe(false);
+      const tool = body.messages.at(-1);
+      const result = JSON.parse(provider === 'openai' ? tool.content : tool.content[0].content);
+      return Response.json(provider === 'openai'
+        ? { id: 'final', model: 'model', choices: [{ index: 0, message: { role: 'assistant', content: result.email }, finish_reason: 'stop' }], usage: { completion_tokens: 7 } }
+        : { id: 'final', type: 'message', role: 'assistant', model: 'model', content: [{ type: 'text', text: result.email }], stop_reason: 'end_turn', usage: { output_tokens: 7 } });
+    }));
+    const response = await client({ provider, onToolCall })(request(provider));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('text/event-stream');
+    expect(onToolCall.mock.calls).toEqual([['lookup', { email }, 'tool-0'], ['lookup', { email }, 'tool-1']]);
+    const wire = await response.text();
+    expect(wire).toContain('bob@example.com');
+    expect(wire).not.toContain('<PII');
+    const acc = adapter.createAccumulator();
+    for (const frame of new SSEParser().parse(wire)) if (!isSSEDone(frame.data)) acc.push(JSON.parse(frame.data));
+    expect(JSON.stringify(acc.finish())).toContain('bob@example.com');
+  });
+
+  it('returns pending calls as SSE when the round budget is zero', async () => {
+    const onToolCall = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => sse(frames(calls(JSON.stringify({ email }))))));
+    const response = await client({ provider, onToolCall, maxToolRounds: 0 })(request(provider));
+    expect(response.headers.get('content-type')).toBe('text/event-stream');
+    expect(await response.text()).toContain('lookup');
+    expect(onToolCall).not.toHaveBeenCalled();
+  });
+
+  it('refuses truncated calls without executing a callback', async () => {
+    const onToolCall = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => sse(frames(calls('{"email":"test"}').slice(0, 2)))));
+    expect((await client({ provider, onToolCall })(request(provider))).status).toBe(502);
+    expect(onToolCall).not.toHaveBeenCalled();
+  });
+
+  it('refuses malformed tool arguments without executing a callback', async () => {
+    const onToolCall = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => sse(frames(calls('{broken')))));
+    expect((await client({ provider, onToolCall })(request(provider))).status).toBe(502);
+    expect(onToolCall).not.toHaveBeenCalled();
+  });
+
+  it('bounds buffered response bytes', async () => {
+    const onToolCall = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => sse(frames(calls('{}')))));
+    const response = await client({ provider, onToolCall, maxToolResponseBytes: 32 })(request(provider));
+    expect(response.status).toBe(502);
+    expect(await response.text()).toContain('maxToolResponseBytes');
+    expect(onToolCall).not.toHaveBeenCalled();
+  });
+
+  it('preserves upstream HTTP errors', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => Response.json({ error: 'rate limit' }, { status: 429 })));
+    const response = await client({ provider, onToolCall: vi.fn() })(request(provider));
+    expect(response.status).toBe(429);
+    expect(await response.json()).toEqual({ error: 'rate limit' });
+  });
+
+  it('cancels an unfinished stream without executing tools', async () => {
+    const abort = new AbortController();
+    const cancel = vi.fn();
+    const onToolCall = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      setTimeout(() => abort.abort(), 10);
+      return new Response(new ReadableStream({ cancel }), { headers: { 'content-type': 'text/event-stream' } });
+    }));
+    await expect(client({ provider, onToolCall })(request(provider, abort.signal))).rejects.toThrow();
+    expect(cancel).toHaveBeenCalled();
+    expect(onToolCall).not.toHaveBeenCalled();
+  });
+});
+
+it('preserves no-tool SSE metadata and rehydrates its content', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => sse(frames([
+    { id: 'original', choices: [{ index: 0, delta: { content: 'Hello' }, finish_reason: null }] },
+    { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }], usage: { total_tokens: 9 } }, '[DONE]',
+  ]))));
+  const callback = vi.fn();
+  const response = await client({ provider: 'openai', onToolCall: callback })(request('openai'));
+  expect(response.headers.get('x-request-id')).toBe('trace');
+  const wire = await response.text();
+  expect(wire).toContain('original'); expect(wire).toContain('total_tokens');
+  expect(callback).not.toHaveBeenCalled();
+});
+
+it('does not run the next tool after cancellation during a callback', async () => {
+  const abort = new AbortController();
+  const callback = vi.fn(async () => { abort.abort(); return 'done'; });
+  vi.stubGlobal('fetch', vi.fn(async () => sse(frames(openaiCalls('{}')))));
+  await expect(client({ provider: 'openai', onToolCall: callback })(request('openai', abort.signal))).rejects.toThrow();
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+it('preserves later-round HTTP failures', async () => {
+  vi.stubGlobal('fetch', vi.fn()
+    .mockResolvedValueOnce(sse(frames(openaiCalls('{}'))))
+    .mockResolvedValueOnce(Response.json({ error: 'unavailable' }, { status: 503 })));
+  const response = await client({ provider: 'openai', onToolCall: async () => 'result' })(request('openai'));
+  expect(response.status).toBe(503);
+  expect(await response.json()).toEqual({ error: 'unavailable' });
+});
+
+it('executes multiple rounds and strips stream_options from JSON continuation requests', async () => {
+  let round = 0;
+  vi.stubGlobal('fetch', vi.fn(async (req: Request) => {
+    const body = await req.json();
+    if (round++ === 0) return sse(frames(openaiCalls('{}')));
+    expect(body.stream).toBe(false);
+    expect(body.stream_options).toBeUndefined();
+    if (round === 2) return Response.json({ choices: [{ message: { role: 'assistant', content: null,
+      tool_calls: [{ id: 'third', type: 'function', function: { name: 'again', arguments: '{}' } }],
+    }, finish_reason: 'tool_calls' }] });
+    return Response.json({ choices: [{ index: 0, message: { role: 'assistant', content: 'finished' }, finish_reason: 'stop' }] });
+  }));
+  const callback = vi.fn().mockResolvedValue('ok');
+  const req = request('openai');
+  const body = await req.json();
+  const response = await client({ provider: 'openai', onToolCall: callback })(new Request(req, { body: JSON.stringify({ ...body, stream_options: { include_usage: true } }) }));
+  expect(callback).toHaveBeenCalledTimes(3);
+  expect(await response.text()).toContain('finished');
+});
+
+it('rehydrates JSON string values without breaking quotes in tool arguments', async () => {
+  const secret = 'a "quoted" value';
+  vi.stubGlobal('fetch', vi.fn(async (req: Request) => {
+    const body = await req.json();
+    if (body.stream) {
+      const value = body.messages.find((m: {role: string}) => m.role === 'user').content;
+      return sse(frames(openaiCalls(JSON.stringify({ value }))));
+    }
+    return Response.json({ choices: [{ index: 0, message: { role: 'assistant', content: 'done' }, finish_reason: 'stop' }] });
+  }));
+  const callback = vi.fn().mockResolvedValue('ok');
+  const req = request('openai');
+  const body = await req.json();
+  body.messages[0].content = secret;
+  const response = await client({ provider: 'openai', onToolCall: callback,
+    anonymizer: { secrets: { enabled: true, redactValues: [secret] } },
+  })(new Request(req, { body: JSON.stringify(body) }));
+  expect(response.status).toBe(200);
+  expect(callback.mock.calls[0]![1]).toEqual({ value: secret });
+});
+
+it('reports local callback failures as server errors', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => sse(frames(openaiCalls('{}')))));
+  const response = await client({ provider: 'openai', onToolCall: async () => { throw new Error('callback failed'); } })(request('openai'));
+  expect(response.status).toBe(500);
+});
+
+it.each([NaN, -1, 0, 1.5, Infinity])('rejects invalid buffer limits: %s', (limit) => {
+  expect(() => client({ maxToolResponseBytes: limit })).toThrow('maxToolResponseBytes');
+});
+
+it('rejects an upstream SSE error before running any tools', async () => {
+  const onToolCall = vi.fn();
+  vi.stubGlobal('fetch', vi.fn(async () => sse(frames([{ error: { message: 'upstream error' } }]))));
+  expect((await client({ provider: 'openai', onToolCall })(request('openai'))).status).toBe(502);
+  expect(onToolCall).not.toHaveBeenCalled();
+});
+
+it('retains Anthropic thinking and signature blocks for the tool continuation', () => {
+  const acc = anthropicStreamingToolLoop.createAccumulator();
+  const messages = anthropicCalls('{}');
+  for (const value of messages.slice(0, -2)) acc.push(value);
+  acc.push({ type: 'content_block_start', index: 2, content_block: { type: 'thinking', thinking: '', signature: '' } });
+  acc.push({ type: 'content_block_delta', index: 2, delta: { type: 'thinking_delta', thinking: 'thinking' } });
+  acc.push({ type: 'content_block_delta', index: 2, delta: { type: 'signature_delta', signature: 'signature' } });
+  acc.push({ type: 'content_block_stop', index: 2 });
+  for (const value of messages.slice(-2)) acc.push(value);
+  expect(JSON.stringify(acc.finish())).toContain('"thinking":"thinking","signature":"signature"');
+});


### PR DESCRIPTION
With `stream: true`, the proxy returned SSE before entering the server-side tool loop, so `onToolCall` never ran. Buffer the first OpenAI or Anthropic stream, assemble interleaved tool calls, and validate completion and arguments before executing callbacks. Reuse the existing JSON loop for subsequent rounds and emit the final response as provider-compatible SSE.

Preserve no-tool SSE events, tool IDs, usage, and Anthropic thinking/signature blocks. Bound buffered responses with `maxToolResponseBytes` and honor cancellation before further callbacks. Reject truncated or malformed streamed calls before side effects. Preserve upstream HTTP status codes, strip streaming-only OpenAI options on continuation requests, and restore JSON argument values without breaking embedded quotes.

This buffers complete responses and does not preserve token-generation latency during a tool loop. OpenAI tool loops require one completion choice. At the round limit, pending calls are returned without execution. These limits are documented.

Validation: reproduced zero callbacks against main; added 27 regression cases across both providers, including interleaving, multiple rounds, final SSE parsing, cancellation, bounds, malformed/truncated streams, HTTP errors, and quoted arguments. All 1,536 tests pass; TypeScript build and lint pass with three existing warnings.

Fixes #51
