### PR TITLE
fix(opencode): redact restored tool arguments in model history

### DIFF
--- a/src/opencode-plugin/plugin.ts
+++ b/src/opencode-plugin/plugin.ts
@@ -219,7 +219,45 @@ export function createRehydraPlugin(options?: RehydraPluginOptions): Plugin {
         for (const msg of output.messages) {
           const session = getSession(msg.info.sessionID);
 
+          // OpenCode retains the rehydrated arguments after tool execution and
+          // serializes them into later model requests. Copy and scrub values so
+          // the execution arguments and JSON property names stay intact.
+          const scrubToolInput = async (value: unknown): Promise<unknown> => {
+            if (typeof value === "string") {
+              const result = await session.anonymize(value, locale, policy);
+              if (result.stats.totalEntities > 0) {
+                hasAnonymized = true;
+                totalScrubbed += result.stats.totalEntities;
+                for (const [type, count] of Object.entries(result.stats.countsByType)) {
+                  scrubbedByType[type] = (scrubbedByType[type] ?? 0) + count;
+                }
+              }
+              return result.anonymizedText;
+            }
+            if (Array.isArray(value)) {
+              const result: unknown[] = [];
+              for (const item of value) result.push(await scrubToolInput(item));
+              return result;
+            }
+            if (value !== null && typeof value === "object") {
+              const entries: Array<[string, unknown]> = [];
+              for (const [key, item] of Object.entries(value)) {
+                entries.push([key, await scrubToolInput(item)]);
+              }
+              return Object.fromEntries(entries);
+            }
+            return value;
+          };
+
           for (const part of msg.parts) {
+            if (part.type === "tool" && part.state !== undefined) {
+              const state = part.state as typeof part.state & { input?: unknown; error?: string };
+              if (state.input !== undefined) state.input = await scrubToolInput(state.input);
+              if (typeof state.error === "string") {
+                state.error = await scrubToolInput(state.error) as string;
+              }
+            }
+
             // Anonymize .text on any part type (text, reasoning, file, patch, etc.)
             if (typeof part.text === "string") {
               const result = await session.anonymize(part.text, locale, policy);

--- a/test/opencode-plugin/plugin.test.ts
+++ b/test/opencode-plugin/plugin.test.ts
@@ -127,6 +127,35 @@ describe("OpenCode Plugin", () => {
   });
 
   describe("messages.transform", () => {
+    it.each(["completed", "error", "running"])("scrubs restored tool arguments in %s history", async (status) => {
+      const original = {
+        command: `printf '%s' '${TEST_SECRET}'`,
+        nested: [{ email: "ada@example.com", count: 2, enabled: true, empty: null }],
+        "ada@example.com": "a property name",
+      };
+      const state = { status, input: original, error: `Failed for ada@example.com: ${TEST_SECRET}` };
+      const output = { messages: [message("assistant", [{ type: "tool", state }])] };
+
+      await hooks["experimental.chat.messages.transform"]!({}, output);
+
+      expect(state.input.command).not.toContain(TEST_SECRET);
+      expect(state.input.nested[0]!.email).toContain("<PII");
+      expect(state.error).not.toContain(TEST_SECRET);
+      expect(state.error).not.toContain("ada@example.com");
+      expect(state.input.nested[0]).toMatchObject({ count: 2, enabled: true, empty: null });
+      expect(state.input["ada@example.com"]).toBe("a property name");
+      expect(original.command).toContain(TEST_SECRET);
+      expect(original.nested[0]!.email).toBe("ada@example.com");
+
+      const once = structuredClone(state.input);
+      await hooks["experimental.chat.messages.transform"]!({}, output);
+      expect(state.input).toEqual(once);
+
+      const execution = { args: structuredClone(state.input) };
+      await hooks["tool.execute.before"]!({ tool: "bash", sessionID: "ses-1", callID: "replay" }, execution);
+      expect(execution.args).toEqual(original);
+    });
+
     it("should anonymize secrets in TextPart", async () => {
       const output = {
         messages: [


### PR DESCRIPTION
OpenCode restores PII placeholders in tool arguments before execution and retains those arguments in conversation history. The next model request previously included the restored values. A real OpenCode 1.18.29 session reproduced this with a masked email passed to a bash command: the command executed correctly, but the next outbound request exposed the email in `tool_calls[].function.arguments`.

Scrub string values in tool input history and error text during `experimental.chat.messages.transform`. Preserve property names, non-string values, and the original execution argument objects. Apply the session's existing policy and include these detections in the redaction statistics.

Validation:
- Regression tests cover completed, failed, and running tool states, nested arguments, repeated transforms, original-object preservation, and restoration for execution.
- Real OpenCode 1.18.29 ran against a local OpenAI-compatible HTTP endpoint with scripted responses, using actual plugin loading, bash execution, and outbound request capture. The tool-history leak failed before the fix and passed after it. This did not use hosted model inference.
- The combined builds of this fix and PRs #100, #102, #103, #104, and #105 passed 1,615 tests, TypeScript build, and lint with three existing warnings. Real sessions also verified environment secrets, address and Git-author redaction, disabled detection types, and response restoration.
- The separate OpenCode title-request bypass remains reproducible; disabling the title agent prevents that request, as documented in #103.

This change does not address the upstream title bypass. No PRs have been merged.
